### PR TITLE
Novel two page landscape

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/reader/novel/ComposePagerPageRenderer.kt
+++ b/app/src/main/java/eu/kanade/presentation/reader/novel/ComposePagerPageRenderer.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.gestures.awaitEachGesture
 import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.PagerState
@@ -182,6 +183,11 @@ private fun resolveComposePagerPageKey(
 internal fun ComposePagerPageRenderer(
     pagerState: PagerState,
     contentPages: List<NovelPageContentPage>,
+    // How many content pages one pager slot shows side by side. 1 is the ordinary single-page
+    // reader; 2 is a landscape two-page spread. contentPageCount below (and therefore the pager's
+    // own slot count) is expressed in slots, not raw content pages, so a slot always addresses
+    // pages [slot * spreadColumns, slot * spreadColumns + spreadColumns - 1].
+    spreadColumns: Int = 1,
     transitionStyle: NovelPageTransitionStyle,
     readerSettings: NovelReaderSettings,
     textColor: Color,
@@ -234,7 +240,9 @@ internal fun ComposePagerPageRenderer(
     @Suppress("NAME_SHADOWING")
     val hasNextChapter = hasNextChapter && showBoundaryChapterPages
     val useBoundaryPreview = shouldUseComposePagerBoundaryPreview(transitionStyle) && showBoundaryChapterPages
-    val contentPageCount = contentPages.size
+    // The pager's own index space is expressed in slots (see spreadColumns above), so every
+    // boundary/key computation below has to work against the slot count, not the raw page count.
+    val contentPageCount = resolveSpreadSlotCount(contentPages.size, spreadColumns)
     val latestToggleUi by rememberUpdatedState(onToggleUi)
     val latestMoveBackward by rememberUpdatedState(onMoveBackward)
     val latestMoveForward by rememberUpdatedState(onMoveForward)
@@ -369,15 +377,18 @@ internal fun ComposePagerPageRenderer(
                 HorizontalChapterSwipeAction.NONE -> null
             }
         }
-        val contentPage = if (boundaryPreview == null) {
-            val actualPage = resolveComposePagerActualPageIndex(
+        val spreadPages = if (boundaryPreview == null) {
+            val spreadSlot = resolveComposePagerActualPageIndex(
                 currentPage = page,
                 contentPageCount = contentPageCount,
                 hasPreviousChapter = hasPreviousChapter,
             )
-            contentPages.getOrElse(actualPage) { NovelPageContentPage(emptyList()) }
+            val firstPage = resolveSpreadSlotFirstPageIndex(spreadSlot, spreadColumns)
+            (firstPage until firstPage + spreadColumns).map { index ->
+                contentPages.getOrElse(index) { NovelPageContentPage(emptyList()) }
+            }
         } else {
-            NovelPageContentPage(emptyList())
+            listOf(NovelPageContentPage(emptyList()))
         }
         val pageOffset = ((pagerState.currentPage - page) + pagerState.currentPageOffsetFraction)
         val transitionSpec = resolveComposePagerTransitionSpec(
@@ -429,9 +440,9 @@ internal fun ComposePagerPageRenderer(
                     textTypeface = textTypeface,
                     chapterTitleTypeface = chapterTitleTypeface,
                 )
-            } else {
+            } else if (spreadPages.size <= 1) {
                 NovelPageReaderPageContent(
-                    contentPage = contentPage,
+                    contentPage = spreadPages.first(),
                     readerSettings = readerSettings,
                     textColor = textColor,
                     textBackground = textBackground,
@@ -454,6 +465,39 @@ internal fun ComposePagerPageRenderer(
                     onPlainTap = onTextTap,
                     onImageLongClick = onImageLongClick,
                 )
+            } else {
+                // Two columns of one spread. Each gets a shared reader-content composable inside
+                // its own half-width slot; the pagination step (NovelReaderContentHost) already
+                // measured text against that half width, so no extra layout math is needed here.
+                Row(modifier = Modifier.fillMaxSize()) {
+                    spreadPages.forEach { spreadPage ->
+                        NovelPageReaderPageContent(
+                            contentPage = spreadPage,
+                            readerSettings = readerSettings,
+                            textColor = textColor,
+                            textBackground = textBackground,
+                            backgroundTexture = backgroundTexture,
+                            nativeTextureStrengthPercent = nativeTextureStrengthPercent,
+                            textTypeface = textTypeface,
+                            chapterTitleTypeface = chapterTitleTypeface,
+                            chapterTitleTextColor = chapterTitleTextColor,
+                            textShadowEnabled = readerSettings.textShadow,
+                            textShadowColor = readerSettings.textShadowColor,
+                            textShadowBlur = readerSettings.textShadowBlur,
+                            textShadowX = readerSettings.textShadowX,
+                            textShadowY = readerSettings.textShadowY,
+                            contentPadding = contentPadding,
+                            statusBarTopPadding = statusBarTopPadding,
+                            ttsHighlightState = ttsHighlightState,
+                            ttsHighlightColor = ttsHighlightColor,
+                            selectionSessionIdProvider = selectionSessionIdProvider,
+                            onSelectedTextSelectionChanged = onSelectedTextSelectionChanged,
+                            onPlainTap = onTextTap,
+                            onImageLongClick = onImageLongClick,
+                            modifier = Modifier.weight(1f),
+                        )
+                    }
+                }
             }
 
             if (abs(transitionSpec.rotationY) > 90f) {

--- a/app/src/main/java/eu/kanade/presentation/reader/novel/GeneralTab.kt
+++ b/app/src/main/java/eu/kanade/presentation/reader/novel/GeneralTab.kt
@@ -202,6 +202,18 @@ fun GeneralTab(
                         )
                     },
                 )
+                AuroraToggleRow(
+                    label = stringResource(AYMR.strings.novel_reader_two_page_landscape),
+                    subtitle = stringResource(AYMR.strings.novel_reader_two_page_landscape_summary),
+                    checked = settings.twoPageLandscape,
+                    onClick = {
+                        update(
+                            !settings.twoPageLandscape,
+                            { o, v -> o.copy(twoPageLandscape = v) },
+                            { preferences.twoPageLandscape().set(it) },
+                        )
+                    },
+                )
                 ListPreferenceWidget(
                     value = settings.pageTransitionStyle,
                     title = stringResource(AYMR.strings.novel_reader_page_transition_style),

--- a/app/src/main/java/eu/kanade/presentation/reader/novel/NovelReaderContentHost.kt
+++ b/app/src/main/java/eu/kanade/presentation/reader/novel/NovelReaderContentHost.kt
@@ -904,6 +904,13 @@ internal fun NovelReaderContentHost(
             preserveSourceTextAlignInNative = state.readerSettings.preserveSourceTextAlignInNative,
         )
     }
+    val novelSpreadMinWidthPx = with(density) { NOVEL_SPREAD_MIN_WIDTH_DP.dp.roundToPx() }
+    val novelSpreadColumns = resolveNovelSpreadColumns(
+        twoPageLandscapeEnabled = state.readerSettings.twoPageLandscape,
+        viewportWidthPx = pageViewportSize.width,
+        viewportHeightPx = pageViewportSize.height,
+        minSpreadWidthPx = novelSpreadMinWidthPx,
+    )
     val pageReaderPages: List<List<PlainPageSlice>> = remember(
         state.chapter.id,
         pageReaderTextBlocks,
@@ -921,6 +928,7 @@ internal fun NovelReaderContentHost(
         pageViewportSize,
         contentPaddingPx,
         statusBarTopPadding,
+        novelSpreadColumns,
     ) {
         if (!shouldPaginatePageReader || pageReaderTextBlocks.isEmpty()) {
             emptyList()
@@ -951,10 +959,20 @@ internal fun NovelReaderContentHost(
                 bookBottomInsetPx +
                 pageFitSafetyPx +
                 navigationBarHeight
+            // The margin is the breathing room around the whole spread, not doubled per column: a
+            // spread column's width is the full content area (screen minus margins) split evenly,
+            // with a thin gap between the two columns rather than each getting its own margin.
+            val contentWidthPx = (screenWidthPx - horizontalPaddingPx).coerceAtLeast(1)
+            val spreadColumnWidthPx = if (novelSpreadColumns > 1) {
+                val gapPx = with(density) { NOVEL_SPREAD_COLUMN_GAP_DP.dp.roundToPx() }
+                ((contentWidthPx - gapPx) / novelSpreadColumns).coerceAtLeast(1)
+            } else {
+                contentWidthPx
+            }
             paginatePlainPageBlocks(
                 textBlocks = pageReaderTextBlocks,
                 paragraphSpacingPx = with(density) { state.readerSettings.paragraphSpacing.dp.roundToPx() },
-                widthPx = (screenWidthPx - horizontalPaddingPx).coerceAtLeast(1),
+                widthPx = spreadColumnWidthPx,
                 heightPx = (screenHeightPx - verticalPaddingPx).coerceAtLeast(1),
                 textSizePx = with(density) { state.readerSettings.fontSize.sp.toPx() },
                 lineHeightMultiplier = state.readerSettings.lineHeight.coerceAtLeast(1f),
@@ -990,6 +1008,7 @@ internal fun NovelReaderContentHost(
         pageViewportSize,
         contentPaddingPx,
         statusBarTopPadding,
+        novelSpreadColumns,
     ) {
         if (!shouldPaginateRichForPageReader) {
             MixedRichPagePagination(blockTexts = emptyList(), pages = emptyList())
@@ -1020,10 +1039,17 @@ internal fun NovelReaderContentHost(
                 bookBottomInsetPx +
                 pageFitSafetyPx +
                 navigationBarHeight
+            val contentWidthPx = (screenWidthPx - horizontalPaddingPx).coerceAtLeast(1)
+            val spreadColumnWidthPx = if (novelSpreadColumns > 1) {
+                val gapPx = with(density) { NOVEL_SPREAD_COLUMN_GAP_DP.dp.roundToPx() }
+                ((contentWidthPx - gapPx) / novelSpreadColumns).coerceAtLeast(1)
+            } else {
+                contentWidthPx
+            }
             paginateMixedRichPageBlocks(
                 richBlocks = pageReaderRichBlocks,
                 paragraphSpacingPx = with(density) { state.readerSettings.paragraphSpacing.dp.roundToPx() },
-                widthPx = (screenWidthPx - horizontalPaddingPx).coerceAtLeast(1),
+                widthPx = spreadColumnWidthPx,
                 heightPx = (screenHeightPx - verticalPaddingPx).coerceAtLeast(1),
                 textSizePx = with(density) { state.readerSettings.fontSize.sp.toPx() },
                 lineHeightMultiplier = state.readerSettings.lineHeight.coerceAtLeast(1f),
@@ -1094,6 +1120,11 @@ internal fun NovelReaderContentHost(
         )
     }
     val pageReaderItemsCount = pageReaderContentPages.size
+    // Every index-based consumer below (TTS, auto-scroll, boundary pages, progress %) keeps
+    // addressing single-column pages via pageReaderItemsCount unmodified; only the pager/page-turn
+    // slot count and virtual-index math are adjusted, so a spread slot pairs pages
+    // [n*columns, n*columns + columns - 1] without touching any of those consumers' own indexing.
+    val pageReaderSpreadSlotCount = resolveSpreadSlotCount(pageReaderItemsCount, novelSpreadColumns)
     // The pager only needs an extra virtual page before/after the chapter while the intermediate
     // "next/previous chapter" placeholder is shown. Seamless chapter transitions hide that
     // placeholder, so the extra slots must not exist either: otherwise the edge page falls back to
@@ -1102,12 +1133,12 @@ internal fun NovelReaderContentHost(
     val composePagerHasPreviousChapter = state.previousChapterId != null && composePagerBoundaryPagesEnabled
     val composePagerHasNextChapter = state.nextChapterId != null && composePagerBoundaryPagesEnabled
     val composePagerVirtualPageCount = remember(
-        pageReaderItemsCount,
+        pageReaderSpreadSlotCount,
         composePagerHasPreviousChapter,
         composePagerHasNextChapter,
     ) {
         resolveComposePagerVirtualPageCount(
-            contentPageCount = pageReaderItemsCount,
+            contentPageCount = pageReaderSpreadSlotCount,
             hasPreviousChapter = composePagerHasPreviousChapter,
             hasNextChapter = composePagerHasNextChapter,
         )
@@ -1153,13 +1184,14 @@ internal fun NovelReaderContentHost(
         pageCount = pageReaderItemsCount.coerceAtLeast(1),
         chapterHandoffTarget = pageReaderChapterHandoffTarget,
     )
+    val initialContentSpreadSlot = resolveSpreadSlotForPageIndex(initialContentPage, novelSpreadColumns)
     val initialPagerPage = if (pageReaderRendererRoute == NovelPageReaderRendererRoute.COMPOSE_PAGER) {
         resolveComposePagerVirtualPageIndex(
-            actualPageIndex = initialContentPage,
+            actualPageIndex = initialContentSpreadSlot,
             hasPreviousChapter = composePagerHasPreviousChapter,
         )
     } else {
-        initialContentPage
+        initialContentSpreadSlot
     }
     val pagerState = key(state.chapter.id) {
         rememberPagerState(
@@ -1168,7 +1200,7 @@ internal fun NovelReaderContentHost(
                 if (pageReaderRendererRoute == NovelPageReaderRendererRoute.COMPOSE_PAGER) {
                     composePagerVirtualPageCount.coerceAtLeast(1)
                 } else {
-                    pageReaderItemsCount.coerceAtLeast(1)
+                    pageReaderSpreadSlotCount.coerceAtLeast(1)
                 }
             },
         )
@@ -1177,17 +1209,19 @@ internal fun NovelReaderContentHost(
         pagerState,
         pageReaderRendererRoute,
         composePagerHasPreviousChapter,
+        novelSpreadColumns,
     ) {
         PageReaderTtsNavigationAdapter(
             navigator = object : PageReaderTtsNavigator {
                 override suspend fun scrollToPage(pageIndex: Int) {
+                    val spreadSlot = resolveSpreadSlotForPageIndex(pageIndex, novelSpreadColumns)
                     val targetPage = if (pageReaderRendererRoute == NovelPageReaderRendererRoute.COMPOSE_PAGER) {
                         resolveComposePagerVirtualPageIndex(
-                            actualPageIndex = pageIndex,
+                            actualPageIndex = spreadSlot,
                             hasPreviousChapter = composePagerHasPreviousChapter,
                         )
                     } else {
-                        pageIndex
+                        spreadSlot
                     }.coerceIn(0, (pagerState.pageCount - 1).coerceAtLeast(0))
                     pagerState.scrollToPage(targetPage)
                 }
@@ -1332,18 +1366,28 @@ internal fun NovelReaderContentHost(
         pagerState.currentPage,
         pageTurnCurrentPage,
         composePagerHasPreviousChapter,
+        pageReaderSpreadSlotCount,
         pageReaderItemsCount,
+        novelSpreadColumns,
     ) {
         derivedStateOf {
-            resolvePageReaderCurrentPage(
+            // pageTurnCurrentPage is already a real page index (PageTurnPageRenderer resolves it
+            // itself before reporting), so only the compose-pager route's slot index needs
+            // expanding back to the first real page of that slot.
+            val slotOrRealIndex = resolvePageReaderCurrentPage(
                 pageReaderRendererRoute = pageReaderRendererRoute,
                 pagerCurrentPage = pagerState.currentPage,
                 pageTurnCurrentPage = pageTurnCurrentPage,
-                composePagerContentPageCount = pageReaderItemsCount,
+                composePagerContentPageCount = pageReaderSpreadSlotCount,
                 composePagerHasPreviousChapter = composePagerHasPreviousChapter,
                 pageTurnContentPageCount = pageReaderItemsCount,
                 pageTurnHasPreviousChapter = composePagerHasPreviousChapter,
             )
+            if (pageReaderRendererRoute == NovelPageReaderRendererRoute.COMPOSE_PAGER) {
+                resolveSpreadSlotFirstPageIndex(slotOrRealIndex, novelSpreadColumns)
+            } else {
+                slotOrRealIndex
+            }
         }
     }
     var isInitialPositionRestored by remember(state.chapter.id) {
@@ -1796,18 +1840,22 @@ internal fun NovelReaderContentHost(
                     requestPageTurnChapterNavigation(PageTurnChapterNavigationDirection.PREVIOUS)
                 }
             } else {
-                val currentPage = pageReaderProgressPageIndex
+                val currentSpreadSlot = resolveSpreadSlotForPageIndex(
+                    pageReaderProgressPageIndex,
+                    novelSpreadColumns,
+                )
                 val currentVirtualPage = resolveComposePagerVirtualPageIndex(
-                    actualPageIndex = currentPage,
+                    actualPageIndex = currentSpreadSlot,
                     hasPreviousChapter = composePagerHasPreviousChapter,
                 )
                 if (currentVirtualPage > 0) {
                     val targetVirtualPage = currentVirtualPage - 1
-                    pageTurnCurrentPage = resolveComposePagerActualPageIndex(
+                    val targetSpreadSlot = resolveComposePagerActualPageIndex(
                         currentPage = targetVirtualPage,
-                        contentPageCount = pageReaderItemsCount,
+                        contentPageCount = pageReaderSpreadSlotCount,
                         hasPreviousChapter = composePagerHasPreviousChapter,
                     )
+                    pageTurnCurrentPage = resolveSpreadSlotFirstPageIndex(targetSpreadSlot, novelSpreadColumns)
                     if (pageAnimationDurationMillis != null) {
                         pagerState.animateScrollToPage(
                             targetVirtualPage,
@@ -1862,19 +1910,23 @@ internal fun NovelReaderContentHost(
                     requestPageTurnChapterNavigation(PageTurnChapterNavigationDirection.NEXT)
                 }
             } else {
-                val currentPage = pageReaderProgressPageIndex
+                val currentSpreadSlot = resolveSpreadSlotForPageIndex(
+                    pageReaderProgressPageIndex,
+                    novelSpreadColumns,
+                )
                 val currentVirtualPage = resolveComposePagerVirtualPageIndex(
-                    actualPageIndex = currentPage,
+                    actualPageIndex = currentSpreadSlot,
                     hasPreviousChapter = composePagerHasPreviousChapter,
                 )
                 val virtualLastPage = composePagerVirtualPageCount - 1
                 if (currentVirtualPage < virtualLastPage) {
                     val targetVirtualPage = currentVirtualPage + 1
-                    pageTurnCurrentPage = resolveComposePagerActualPageIndex(
+                    val targetSpreadSlot = resolveComposePagerActualPageIndex(
                         currentPage = targetVirtualPage,
-                        contentPageCount = pageReaderItemsCount,
+                        contentPageCount = pageReaderSpreadSlotCount,
                         hasPreviousChapter = composePagerHasPreviousChapter,
                     )
+                    pageTurnCurrentPage = resolveSpreadSlotFirstPageIndex(targetSpreadSlot, novelSpreadColumns)
                     if (pageAnimationDurationMillis != null) {
                         pagerState.animateScrollToPage(
                             targetVirtualPage,
@@ -2397,6 +2449,7 @@ internal fun NovelReaderContentHost(
                         ComposePagerPageRenderer(
                             pagerState = pagerState,
                             contentPages = pageReaderContentPages,
+                            spreadColumns = novelSpreadColumns,
                             transitionStyle = activePageTransitionStyle,
                             showBoundaryChapterPages = !seamlessChapterTransitionEnabled,
                             readerSettings = state.readerSettings,
@@ -2456,6 +2509,7 @@ internal fun NovelReaderContentHost(
                             pagerState = pagerState,
                             chapterId = state.chapter.id,
                             contentPages = pageReaderContentPages,
+                            spreadColumns = novelSpreadColumns,
                             transitionStyle = activePageTransitionStyle,
                             showBoundaryChapterPages = !seamlessChapterTransitionEnabled,
                             readerSettings = state.readerSettings,
@@ -3626,6 +3680,8 @@ internal fun NovelReaderContentHost(
                 isBookMode = isBookMode,
                 pageReaderRendererRoute = pageReaderRendererRoute,
                 pageReaderItemsCount = pageReaderItemsCount,
+                pageReaderSpreadSlotCount = pageReaderSpreadSlotCount,
+                spreadColumns = novelSpreadColumns,
                 composePagerHasPreviousChapter = composePagerHasPreviousChapter,
                 nativeScrollItemsCount = nativeScrollItemsCount,
                 pageReaderProgressPageIndex = pageReaderProgressPageIndex,
@@ -3687,8 +3743,9 @@ internal fun NovelReaderContentHost(
                     if (pageReaderRendererRoute == NovelPageReaderRendererRoute.PAGE_TURN_RENDERER) {
                         pageTurnRequestedPage = target
                     } else {
+                        val targetSpreadSlot = resolveSpreadSlotForPageIndex(target, novelSpreadColumns)
                         val virtualTarget = resolveComposePagerVirtualPageIndex(
-                            actualPageIndex = target,
+                            actualPageIndex = targetSpreadSlot,
                             hasPreviousChapter = composePagerHasPreviousChapter,
                         )
                         coroutineScope.launch {

--- a/app/src/main/java/eu/kanade/presentation/reader/novel/NovelReaderContentHost.kt
+++ b/app/src/main/java/eu/kanade/presentation/reader/novel/NovelReaderContentHost.kt
@@ -2504,6 +2504,65 @@ internal fun NovelReaderContentHost(
                             selectionSessionIdProvider = nextSelectedTextSelectionSessionId,
                             onSelectedTextSelectionChanged = onSelectedTextSelectionChanged,
                         )
+                    } else if (pageReaderRendererRoute == NovelPageReaderRendererRoute.PAGE_TURN_RENDERER &&
+                        novelSpreadColumns > 1
+                    ) {
+                        // The curl library always folds across its own full measured width, so a
+                        // single wide PageCurl behind a two-column spread curls the whole spread as
+                        // one leaf, edge to edge, ignoring the spine. SpreadPageTurnPageRenderer runs
+                        // two half-width PageCurl surfaces instead, one per column, so the fold
+                        // anchors at the spine like a real book page.
+                        SpreadPageTurnPageRenderer(
+                            pagerState = pagerState,
+                            chapterId = state.chapter.id,
+                            contentPages = pageReaderContentPages,
+                            transitionStyle = activePageTransitionStyle,
+                            showBoundaryChapterPages = !seamlessChapterTransitionEnabled,
+                            readerSettings = state.readerSettings,
+                            textColor = textColor,
+                            textBackground = textBackground,
+                            chapterTitleTextColor = chapterTitleTextColor,
+                            backgroundTexture = activeBackgroundTexture,
+                            nativeTextureStrengthPercent = state.readerSettings.nativeTextureStrengthPercent,
+                            backgroundImageModel = if (isBackgroundMode) backgroundImageModel else null,
+                            backgroundModeIdentity = if (isBackgroundMode) backgroundModeIdentity else "",
+                            isBackgroundMode = isBackgroundMode,
+                            activeBackgroundTexture = activeBackgroundTexture,
+                            activeOledEdgeGradient = activeOledEdgeGradient,
+                            isDarkTheme = isDarkTheme,
+                            pageEdgeShadow = state.readerSettings.pageEdgeShadow,
+                            pageEdgeShadowAlpha = state.readerSettings.pageEdgeShadowAlpha,
+                            textTypeface = composeTypeface,
+                            chapterTitleTypeface = chapterTitleTypeface,
+                            contentPadding = contentPaddingPx,
+                            statusBarTopPadding = statusBarTopPadding,
+                            ttsHighlightState = ttsHighlightState,
+                            ttsHighlightColor = ttsHighlightColor,
+                            hasPreviousChapter = state.previousChapterId != null,
+                            previousChapterName = state.previousChapterName,
+                            hasNextChapter = state.nextChapterId != null,
+                            nextChapterName = state.nextChapterName,
+                            previousChapterLabel = stringResource(MR.strings.action_previous_chapter),
+                            nextChapterLabel = stringResource(MR.strings.action_next_chapter),
+                            boundaryChapterHint = stringResource(MR.strings.reader_boundary_release_to_open),
+                            onToggleUi = { onSetShowReaderUi(!showReaderUi) },
+                            requestedPage = pageTurnRequestedPage,
+                            onRequestedPageConsumed = { pageTurnRequestedPage = -1 },
+                            onCurrentPageChange = { pageTurnCurrentPage = it },
+                            onOpenPreviousChapter = {
+                                openPreviousChapterFromReader()
+                            },
+                            onOpenNextChapter = { openNextChapterFromReader() },
+                            chapterNavigationRequest = pageTurnChapterNavigationRequest,
+                            onChapterNavigationRequestConsumed = {
+                                pageTurnChapterNavigationRequest = null
+                            },
+                            onTextTap = { tapX, tapY, width, height ->
+                                latestReaderShortTapHandler(tapX, tapY, width, height)
+                            },
+                            selectionSessionIdProvider = nextSelectedTextSelectionSessionId,
+                            onSelectedTextSelectionChanged = onSelectedTextSelectionChanged,
+                        )
                     } else if (pageReaderRendererRoute == NovelPageReaderRendererRoute.PAGE_TURN_RENDERER) {
                         PageTurnPageRenderer(
                             pagerState = pagerState,

--- a/app/src/main/java/eu/kanade/presentation/reader/novel/NovelReaderInteraction.kt
+++ b/app/src/main/java/eu/kanade/presentation/reader/novel/NovelReaderInteraction.kt
@@ -666,7 +666,9 @@ internal fun resolveReaderVerticalSeekbarValue(
         showWebView -> webProgressPercent.coerceIn(0, 100) / 100f
         usePageReader -> {
             val max = (seekbarItemsCount - 1).coerceAtLeast(1)
-            val current = resolvePageReaderCurrentPage(
+            // Only the compose-pager route addresses spread slots; pageTurnCurrentPage is already
+            // a real page (PageTurnPageRenderer resolves it before reporting).
+            val slotOrRealIndex = resolvePageReaderCurrentPage(
                 pageReaderRendererRoute = pageReaderRendererRoute,
                 pagerCurrentPage = pagerCurrentPage,
                 pageTurnCurrentPage = pageTurnCurrentPage,
@@ -675,6 +677,11 @@ internal fun resolveReaderVerticalSeekbarValue(
                 pageTurnContentPageCount = pageTurnContentPageCount,
                 pageTurnHasPreviousChapter = pageTurnHasPreviousChapter,
             )
+            val current = if (pageReaderRendererRoute == NovelPageReaderRendererRoute.COMPOSE_PAGER) {
+                resolveSpreadSlotFirstPageIndex(slotOrRealIndex, spreadColumns)
+            } else {
+                slotOrRealIndex
+            }
             current.toFloat() / max.toFloat()
         }
         else -> {

--- a/app/src/main/java/eu/kanade/presentation/reader/novel/NovelReaderInteraction.kt
+++ b/app/src/main/java/eu/kanade/presentation/reader/novel/NovelReaderInteraction.kt
@@ -320,6 +320,30 @@ internal fun shouldPaginateForPageReader(
     return pageReaderEnabled && contentBlocksCount > 0
 }
 
+/**
+ * Minimum viewport width, in px, a two-page spread is allowed to activate at. Below this, a
+ * half-width column would squeeze text too narrow to read comfortably — manga art tolerates a
+ * narrow half, running text does not, so unlike the manga pager this needs a width floor and not
+ * just an orientation check. 600dp mirrors Android's own sw600dp tablet breakpoint.
+ */
+internal const val NOVEL_SPREAD_MIN_WIDTH_DP = 600
+
+/** Gap between the two columns of a spread. Deliberately independent of the page margin: the
+ * margin is breathing room around the whole spread, this is the seam between its two halves. */
+internal const val NOVEL_SPREAD_COLUMN_GAP_DP = 24
+
+/** How many text columns one pager slot should show side by side. */
+internal fun resolveNovelSpreadColumns(
+    twoPageLandscapeEnabled: Boolean,
+    viewportWidthPx: Int,
+    viewportHeightPx: Int,
+    minSpreadWidthPx: Int,
+): Int {
+    val isLandscape = viewportWidthPx > viewportHeightPx
+    val isWideEnough = viewportWidthPx >= minSpreadWidthPx
+    return if (twoPageLandscapeEnabled && isLandscape && isWideEnough) 2 else 1
+}
+
 internal fun shouldShowPageReaderDismissLayer(
     showReaderUi: Boolean,
     usePageReader: Boolean,
@@ -468,6 +492,28 @@ internal fun shouldUseComposePagerBoundaryPreview(
     }
 }
 
+/**
+ * Number of pager slots [contentPageCount] single-column pages collapse into when every slot
+ * shows [columnsPerSpread] of them side by side. A trailing odd page still gets its own slot
+ * (rendered with an empty second column), the same way a physical book's last page can be a
+ * lone right-hand page facing nothing.
+ */
+internal fun resolveSpreadSlotCount(contentPageCount: Int, columnsPerSpread: Int): Int {
+    val safeColumns = columnsPerSpread.coerceAtLeast(1)
+    return ceil(contentPageCount.coerceAtLeast(1).toDouble() / safeColumns).toInt().coerceAtLeast(1)
+}
+
+/** First single-column page index shown in spread slot [spreadSlot]. */
+internal fun resolveSpreadSlotFirstPageIndex(spreadSlot: Int, columnsPerSpread: Int): Int {
+    return spreadSlot.coerceAtLeast(0) * columnsPerSpread.coerceAtLeast(1)
+}
+
+/** Which spread slot [pageIndex] (a single-column page index) is shown in. */
+internal fun resolveSpreadSlotForPageIndex(pageIndex: Int, columnsPerSpread: Int): Int {
+    val safeColumns = columnsPerSpread.coerceAtLeast(1)
+    return pageIndex.coerceAtLeast(0) / safeColumns
+}
+
 internal fun resolveComposePagerVirtualPageCount(
     contentPageCount: Int,
     hasPreviousChapter: Boolean,
@@ -611,6 +657,7 @@ internal fun resolveReaderVerticalSeekbarValue(
     nativeFirstVisibleItemIndex: Int = 0,
     nativeCanScrollForward: Boolean = true,
     bookModeEnabled: Boolean = false,
+    spreadColumns: Int = 1,
 ): Float {
     return when {
         bookModeEnabled -> {

--- a/app/src/main/java/eu/kanade/presentation/reader/novel/NovelReaderVerticalSeekbar.kt
+++ b/app/src/main/java/eu/kanade/presentation/reader/novel/NovelReaderVerticalSeekbar.kt
@@ -63,6 +63,11 @@ internal fun NovelReaderVerticalSeekbar(
     isBookMode: Boolean,
     pageReaderRendererRoute: NovelPageReaderRendererRoute,
     pageReaderItemsCount: Int,
+    // pagerCurrentPage above is a spread-slot index when a two-page spread is active, so resolving
+    // it back to a real page (for the seekbar's own position math) needs the slot count, not the
+    // real page count pageReaderItemsCount holds.
+    pageReaderSpreadSlotCount: Int = pageReaderItemsCount,
+    spreadColumns: Int = 1,
     composePagerHasPreviousChapter: Boolean,
     nativeScrollItemsCount: Int,
     pageReaderProgressPageIndex: Int,
@@ -126,6 +131,7 @@ internal fun NovelReaderVerticalSeekbar(
             seekbarItemsCount,
             readingProgressPercent,
             isBookMode,
+            spreadColumns,
         ) {
             derivedStateOf {
                 resolveReaderVerticalSeekbarValue(
@@ -135,7 +141,7 @@ internal fun NovelReaderVerticalSeekbar(
                     pageReaderRendererRoute = pageReaderRendererRoute,
                     pagerCurrentPage = pagerCurrentPage,
                     pageTurnCurrentPage = pageTurnCurrentPage,
-                    composePagerContentPageCount = pageReaderItemsCount,
+                    composePagerContentPageCount = pageReaderSpreadSlotCount,
                     composePagerHasPreviousChapter = composePagerHasPreviousChapter,
                     pageTurnContentPageCount = pageReaderItemsCount,
                     pageTurnHasPreviousChapter = composePagerHasPreviousChapter,
@@ -144,6 +150,7 @@ internal fun NovelReaderVerticalSeekbar(
                     nativeFirstVisibleItemIndex = firstVisibleItemIndex,
                     nativeCanScrollForward = canScrollForward,
                     bookModeEnabled = isBookMode,
+                    spreadColumns = spreadColumns,
                 )
             }
         }

--- a/app/src/main/java/eu/kanade/presentation/reader/novel/PageTurnPageRenderer.kt
+++ b/app/src/main/java/eu/kanade/presentation/reader/novel/PageTurnPageRenderer.kt
@@ -7,6 +7,7 @@ import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.AnimationVector4D
 import androidx.compose.animation.core.keyframes
 import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
@@ -509,6 +510,9 @@ internal fun PageTurnPageRenderer(
     pagerState: PagerState,
     chapterId: Long,
     contentPages: List<NovelPageContentPage>,
+    // Same meaning as ComposePagerPageRenderer's spreadColumns: how many content pages one curl
+    // "page" shows side by side.
+    spreadColumns: Int = 1,
     transitionStyle: NovelPageTransitionStyle,
     readerSettings: NovelReaderSettings,
     textColor: Color,
@@ -569,7 +573,10 @@ internal fun PageTurnPageRenderer(
     val safeContentPages = remember(contentPages) {
         contentPages.ifEmpty { listOf(NovelPageContentPage(emptyList())) }
     }
-    val actualPageCount = safeContentPages.size
+    // The curl renderer's own index space is expressed in spread slots (see spreadColumns on the
+    // signature), the same way the pager's page count is: a slot addresses
+    // [slot * spreadColumns, slot * spreadColumns + spreadColumns - 1] of safeContentPages.
+    val actualPageCount = resolveSpreadSlotCount(safeContentPages.size, spreadColumns)
     val virtualPageCount = remember(actualPageCount, hasPreviousChapter, hasNextChapter) {
         resolvePageTurnRendererVirtualPageCount(
             contentPageCount = actualPageCount,
@@ -577,7 +584,7 @@ internal fun PageTurnPageRenderer(
             hasNextChapter = hasNextChapter,
         )
     }
-    val pagerCurrentPage = pagerState.currentPage.coerceIn(0, safeContentPages.lastIndex)
+    val pagerCurrentPage = pagerState.currentPage.coerceIn(0, actualPageCount - 1)
     val initialVirtualPage = remember(pagerCurrentPage, hasPreviousChapter) {
         resolvePageTurnRendererVirtualPageIndex(
             actualPageIndex = pagerCurrentPage,
@@ -626,7 +633,7 @@ internal fun PageTurnPageRenderer(
     val latestChapterNavigationRequest by rememberUpdatedState(chapterNavigationRequest)
     val latestChapterNavigationRequestConsumed by rememberUpdatedState(onChapterNavigationRequestConsumed)
     val latestRendererConfig by rememberUpdatedState(rendererConfig)
-    val latestPageCount by rememberUpdatedState(safeContentPages.size)
+    val latestPageCount by rememberUpdatedState(actualPageCount)
     val latestHasPreviousBoundaryPage by rememberUpdatedState(hasPreviousChapter)
     val latestHasPreviousChapter by rememberUpdatedState(hasPreviousChapterNavigation)
     val latestHasNextChapter by rememberUpdatedState(hasNextChapterNavigation)
@@ -727,7 +734,7 @@ internal fun PageTurnPageRenderer(
         pageCurlConfig.dragBackwardEnabled = currentPage > 0
         pageCurlConfig.dragForwardEnabled = currentPage < virtualPageCount - 1
         pageCurlConfig.tapBackwardEnabled = latestTapToScrollEnabled && currentActualPage > 0
-        pageCurlConfig.tapForwardEnabled = latestTapToScrollEnabled && currentActualPage < safeContentPages.lastIndex
+        pageCurlConfig.tapForwardEnabled = latestTapToScrollEnabled && currentActualPage < actualPageCount - 1
         pageCurlConfig.tapCustomEnabled = rendererConfig.tapCustomEnabled
         pageCurlConfig.dragInteraction = dragInteraction
         pageCurlConfig.tapInteraction = tapInteraction
@@ -793,14 +800,16 @@ internal fun PageTurnPageRenderer(
                     hasNextChapter = hasNextChapter,
                 )
                 if (boundaryTarget == HorizontalChapterSwipeAction.NONE) {
-                    val targetPage = resolvePageTurnRendererProgressPageIndex(
+                    val targetSpreadSlot = resolvePageTurnRendererProgressPageIndex(
                         currentPage = targetVirtualPage,
                         contentPageCount = actualPageCount,
                         hasPreviousChapter = hasPreviousChapter,
                     )
-                    latestCurrentPageChange(targetPage)
-                    if (targetPage != pagerState.currentPage) {
-                        pagerState.scrollToPage(targetPage)
+                    // onCurrentPageChange reports a real page index (its callers persist/compare it
+                    // against pageReaderItemsCount), pagerState stays in the pager's own slot space.
+                    latestCurrentPageChange(resolveSpreadSlotFirstPageIndex(targetSpreadSlot, spreadColumns))
+                    if (targetSpreadSlot != pagerState.currentPage) {
+                        pagerState.scrollToPage(targetSpreadSlot)
                     }
                 }
             }
@@ -809,8 +818,12 @@ internal fun PageTurnPageRenderer(
     LaunchedEffect(latestRequestedPage, actualPageCount, hasPreviousChapter) {
         val targetPage = latestRequestedPage
         if (targetPage < 0 || safeContentPages.isEmpty()) return@LaunchedEffect
+        val targetSpreadSlot = resolveSpreadSlotForPageIndex(
+            targetPage.coerceIn(0, safeContentPages.lastIndex),
+            spreadColumns,
+        )
         val clampedTarget = resolvePageTurnRendererVirtualPageIndex(
-            actualPageIndex = targetPage.coerceIn(0, safeContentPages.lastIndex),
+            actualPageIndex = targetSpreadSlot,
             hasPreviousChapter = hasPreviousChapter,
         )
         if (pageCurlState.current != clampedTarget) {
@@ -902,20 +915,24 @@ internal fun PageTurnPageRenderer(
                     HorizontalChapterSwipeAction.NONE -> null
                 }
             }
-            val contentPage = if (boundaryPreview == null) {
-                val actualPage = resolvePageTurnRendererProgressPageIndex(
+            val spreadPages = if (boundaryPreview == null) {
+                val spreadSlot = resolvePageTurnRendererProgressPageIndex(
                     currentPage = page,
                     contentPageCount = actualPageCount,
                     hasPreviousChapter = hasPreviousChapter,
                 )
-                safeContentPages.getOrElse(actualPage) { NovelPageContentPage(emptyList()) }
+                val firstPage = resolveSpreadSlotFirstPageIndex(spreadSlot, spreadColumns)
+                (firstPage until firstPage + spreadColumns).map { index ->
+                    safeContentPages.getOrElse(index) { NovelPageContentPage(emptyList()) }
+                }
             } else {
-                NovelPageContentPage(emptyList())
+                listOf(NovelPageContentPage(emptyList()))
             }
+            val contentPage = spreadPages.first()
             val pageTexture = if (isBackgroundMode) activeBackgroundTexture else backgroundTexture
             val pageTextureStrengthPercent = if (isBackgroundMode) 0 else nativeTextureStrengthPercent
             val pageSurfaceColor = if (isBackgroundMode) null else rendererConfig.backPageColor
-            val pageContentIdentity = boundaryPreview ?: contentPage
+            val pageContentIdentity = boundaryPreview ?: spreadPages
             val pageSnapshotKey = resolveNovelPageTurnSnapshotKey(
                 style = rendererConfig.style,
                 pageIndex = page,
@@ -984,7 +1001,7 @@ internal fun PageTurnPageRenderer(
                         textTypeface = textTypeface,
                         chapterTitleTypeface = chapterTitleTypeface,
                     )
-                } else {
+                } else if (spreadPages.size <= 1) {
                     NovelPageReaderPageContent(
                         contentPage = contentPage,
                         readerSettings = readerSettings,
@@ -1010,6 +1027,37 @@ internal fun PageTurnPageRenderer(
                         onPlainTap = onTextTap,
                         touchHandlingEnabled = false,
                     )
+                } else {
+                    Row(modifier = Modifier.fillMaxSize()) {
+                        spreadPages.forEach { spreadPage ->
+                            NovelPageReaderPageContent(
+                                contentPage = spreadPage,
+                                readerSettings = readerSettings,
+                                textColor = textColor,
+                                textBackground = textBackground,
+                                pageSurfaceColor = pageSurfaceColor,
+                                backgroundTexture = pageTexture,
+                                nativeTextureStrengthPercent = pageTextureStrengthPercent,
+                                chapterTitleTextColor = chapterTitleTextColor,
+                                textTypeface = textTypeface,
+                                chapterTitleTypeface = chapterTitleTypeface,
+                                textShadowEnabled = readerSettings.textShadow,
+                                textShadowColor = readerSettings.textShadowColor,
+                                textShadowBlur = readerSettings.textShadowBlur,
+                                textShadowX = readerSettings.textShadowX,
+                                textShadowY = readerSettings.textShadowY,
+                                contentPadding = contentPadding,
+                                statusBarTopPadding = statusBarTopPadding,
+                                ttsHighlightState = ttsHighlightState,
+                                ttsHighlightColor = ttsHighlightColor,
+                                selectionSessionIdProvider = selectionSessionIdProvider,
+                                onSelectedTextSelectionChanged = onSelectedTextSelectionChanged,
+                                onPlainTap = onTextTap,
+                                touchHandlingEnabled = false,
+                                modifier = Modifier.weight(1f),
+                            )
+                        }
+                    }
                 }
             }
         }

--- a/app/src/main/java/eu/kanade/presentation/reader/novel/PageTurnPageRenderer.kt
+++ b/app/src/main/java/eu/kanade/presentation/reader/novel/PageTurnPageRenderer.kt
@@ -441,7 +441,7 @@ private fun createPageTurnDragInteraction(
     }
 }
 
-private fun createPageTurnAnimation(
+internal fun createPageTurnAnimation(
     animationDurationMillis: Int,
     forward: Boolean,
     curlAmount: Float,
@@ -491,14 +491,14 @@ internal fun resolvePageTurnCurlMidEdge(
     }
 }
 
-private fun Size.startEdge(): Edge {
+internal fun Size.startEdge(): Edge {
     return Edge(
         top = Offset(0f, 0f),
         bottom = Offset(0f, height),
     )
 }
 
-private fun Size.endEdge(): Edge {
+internal fun Size.endEdge(): Edge {
     return Edge(
         top = Offset(width, height),
         bottom = Offset(width, height),

--- a/app/src/main/java/eu/kanade/presentation/reader/novel/SpreadPageTurnPageRenderer.kt
+++ b/app/src/main/java/eu/kanade/presentation/reader/novel/SpreadPageTurnPageRenderer.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpOffset
@@ -198,6 +199,15 @@ internal fun SpreadPageTurnPageRenderer(
     // Advances both surfaces together: the one facing the turn direction plays the real fold, the
     // other jumps straight to its new page with no visible animation of its own (snap()), the same
     // way the spine-side page of a real book is simply "already there" once you see it.
+    //
+    // eu.wewox.pagecurl.page.PageCurl's own drag/animation geometry always references the widget's
+    // own size.width (NewEdgeCreator anchors on it, and PageCurlState.setup's forward Animatable
+    // always starts at the right edge): using prev()/backward on an unmirrored widget opens the
+    // current page from its own left edge outward, not a new page sliding in over it like a book
+    // leaf. The left surface is mirrored (see SpreadColumnCurl) so the library's right-referenced
+    // geometry lands on the screen's actual left edge — which means the left surface always calls
+    // next()/forward internally, for both book directions; only which surface plays the real
+    // animation and which one just snaps changes.
     fun turnForward() {
         tapCoroutineScope.launch {
             rightCurlState.next(
@@ -214,10 +224,10 @@ internal fun SpreadPageTurnPageRenderer(
     }
     fun turnBackward() {
         tapCoroutineScope.launch {
-            leftCurlState.prev(
+            leftCurlState.next(
                 createPageTurnAnimation(
                     animationDurationMillis = latestRendererConfig.preset.animationDurationMillis,
-                    forward = false,
+                    forward = true,
                     curlAmount = latestRendererConfig.preset.curlAmount,
                 ),
             )
@@ -275,21 +285,29 @@ internal fun SpreadPageTurnPageRenderer(
         leftPageCurlConfig.shadowAlpha = rendererConfig.preset.shadowAlpha
         leftPageCurlConfig.shadowRadius = rendererConfig.shadowRadiusDp.dp
         leftPageCurlConfig.shadowOffset = DpOffset(rendererConfig.shadowOffsetXDp.dp, 0.dp)
-        // The left surface only ever turns backward: its fold lives at the outer (left) edge.
-        leftPageCurlConfig.dragForwardEnabled = false
-        leftPageCurlConfig.dragBackwardEnabled = currentVirtualSlot > 0
-        leftPageCurlConfig.tapBackwardEnabled = latestTapToScrollEnabled && currentSpreadSlot > 0
-        leftPageCurlConfig.tapForwardEnabled = false
+        // The library's own drag-success target (dragTargetReachFraction) is tuned for a
+        // full-width single page (it can sit well past the halfway point). Each spread surface is
+        // only half that width, so the fold's release target has to be the spine itself — the
+        // reach a drag needs to travel to at most doubles compared to a full-width page.
+        val spineReach = 0.5f
+        // The left surface is mirrored (see SpreadColumnCurl), so the library's own forward
+        // mechanism — which always references size.width internally — is what turnBackward() drives
+        // here; the fold still lives at the outer (left) edge of the screen once un-mirrored. The
+        // library's backward mechanism is unused on this surface.
+        leftPageCurlConfig.dragForwardEnabled = currentVirtualSlot > 0
+        leftPageCurlConfig.dragBackwardEnabled = false
+        leftPageCurlConfig.tapBackwardEnabled = false
+        leftPageCurlConfig.tapForwardEnabled = latestTapToScrollEnabled && currentSpreadSlot > 0
         leftPageCurlConfig.tapCustomEnabled = rendererConfig.tapCustomEnabled
         leftPageCurlConfig.dragInteraction = PageCurlConfig.StartEndDragInteraction(
             pointerBehavior = rendererConfig.dragPointerBehavior,
             backward = PageCurlConfig.StartEndDragInteraction.Config(
-                start = Rect(0f, 0f, rendererConfig.dragActivationEdgeFraction, 1f),
-                end = Rect(1f - rendererConfig.dragTargetReachFraction, 0f, 1f, 1f),
+                start = Rect(0f, 0f, 0f, 1f),
+                end = Rect(0f, 0f, 0f, 1f),
             ),
             forward = PageCurlConfig.StartEndDragInteraction.Config(
-                start = Rect(1f, 0f, 1f, 1f),
-                end = Rect(1f, 0f, 1f, 1f),
+                start = Rect(1f - rendererConfig.dragActivationEdgeFraction, 0f, 1f, 1f),
+                end = Rect(0f, 0f, spineReach, 1f),
             ),
         )
         leftPageCurlConfig.tapInteraction = tapInteraction
@@ -314,7 +332,7 @@ internal fun SpreadPageTurnPageRenderer(
             ),
             forward = PageCurlConfig.StartEndDragInteraction.Config(
                 start = Rect(1f - rendererConfig.dragActivationEdgeFraction, 0f, 1f, 1f),
-                end = Rect(0f, 0f, rendererConfig.dragTargetReachFraction, 1f),
+                end = Rect(0f, 0f, spineReach, 1f),
             ),
         )
         rightPageCurlConfig.tapInteraction = tapInteraction
@@ -489,6 +507,7 @@ internal fun SpreadPageTurnPageRenderer(
         Row(modifier = Modifier.fillMaxSize()) {
             SpreadColumnCurl(
                 modifier = Modifier.fillMaxWidth(0.5f),
+                mirrored = true,
                 columnOffset = 0,
                 pageCurlState = leftCurlState,
                 pageCurlConfig = leftPageCurlConfig,
@@ -534,6 +553,7 @@ internal fun SpreadPageTurnPageRenderer(
             )
             SpreadColumnCurl(
                 modifier = Modifier.fillMaxWidth(1f),
+                mirrored = false,
                 columnOffset = 1,
                 pageCurlState = rightCurlState,
                 pageCurlConfig = rightPageCurlConfig,
@@ -661,6 +681,14 @@ private fun handleSpreadCustomTap(
 @Composable
 private fun SpreadColumnCurl(
     modifier: Modifier,
+    // eu.wewox.pagecurl.page.PageCurl's own drag/animation geometry always references the widget's
+    // right edge (NewEdgeCreator anchors on size.width, PageCurlState.setup's forward Animatable
+    // always runs right-to-left): using the library's backward mechanism unmirrored opens the
+    // current page from its own left edge outward instead of bringing a new page in from the left
+    // like a book leaf. Mirroring the whole widget horizontally (and un-mirroring its content) makes
+    // the library's own right-referenced geometry land on the screen's actual left edge, so this
+    // surface's fold anchors at the spine the same way the unmirrored right surface already does.
+    mirrored: Boolean,
     columnOffset: Int,
     pageCurlState: PageCurlState,
     pageCurlConfig: PageCurlConfig,
@@ -704,12 +732,17 @@ private fun SpreadColumnCurl(
     onSelectedTextSelectionChanged: (NovelSelectedTextSelection?) -> Unit,
     onTextTap: (Float, Float, Float, Float) -> Unit,
 ) {
+    val curlModifier = if (mirrored) {
+        modifier.fillMaxSize().graphicsLayer(scaleX = -1f)
+    } else {
+        modifier.fillMaxSize()
+    }
     PageCurl(
         count = virtualSlotCount,
         key = { it },
         state = pageCurlState,
         config = pageCurlConfig,
-        modifier = modifier.fillMaxSize(),
+        modifier = curlModifier,
     ) { page ->
         val boundaryPreview = if (!showBoundaryChapterPages) {
             null
@@ -793,11 +826,16 @@ private fun SpreadColumnCurl(
             textShadowY = readerSettings.textShadowY,
             bionicReading = readerSettings.bionicReading,
         )
+        val contentModifier = if (mirrored) {
+            Modifier.fillMaxSize().graphicsLayer(scaleX = -1f)
+        } else {
+            Modifier.fillMaxSize()
+        }
         NovelPageTurnSnapshotRenderer(
             snapshotKey = pageSnapshotKey,
             snapshotCache = snapshotCache,
             preferCachedBitmap = false,
-            modifier = Modifier.fillMaxSize(),
+            modifier = contentModifier,
         ) {
             NovelAtmosphereBackground(
                 backgroundColor = textBackground,

--- a/app/src/main/java/eu/kanade/presentation/reader/novel/SpreadPageTurnPageRenderer.kt
+++ b/app/src/main/java/eu/kanade/presentation/reader/novel/SpreadPageTurnPageRenderer.kt
@@ -1,0 +1,852 @@
+@file:OptIn(eu.wewox.pagecurl.ExperimentalPageCurlApi::class)
+
+package eu.kanade.presentation.reader.novel
+
+import android.graphics.Typeface
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.AnimationVector4D
+import androidx.compose.animation.core.snap
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.pager.PagerState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.DpOffset
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.dp
+import eu.kanade.tachiyomi.ui.reader.novel.NovelSelectedTextSelection
+import eu.kanade.tachiyomi.ui.reader.novel.setting.NovelPageTransitionStyle
+import eu.kanade.tachiyomi.ui.reader.novel.setting.NovelReaderBackgroundTexture
+import eu.kanade.tachiyomi.ui.reader.novel.setting.NovelReaderSettings
+import eu.kanade.tachiyomi.ui.reader.novel.setting.NovelReaderTapZoneAction
+import eu.kanade.tachiyomi.ui.reader.novel.setting.TextAlign
+import eu.kanade.tachiyomi.ui.reader.novel.setting.parseNovelReaderTapZoneActions
+import eu.kanade.tachiyomi.ui.reader.novel.setting.resolveConfiguredNovelReaderTapAction
+import eu.wewox.pagecurl.config.PageCurlConfig
+import eu.wewox.pagecurl.config.rememberPageCurlConfig
+import eu.wewox.pagecurl.page.Edge
+import eu.wewox.pagecurl.page.PageCurl
+import eu.wewox.pagecurl.page.PageCurlState
+import eu.wewox.pagecurl.page.rememberPageCurlState
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.launch
+
+/**
+ * Two-page spread variant of [PageTurnPageRenderer].
+ *
+ * eu.wewox.pagecurl.page.PageCurl always folds across its own full measured width: there is no
+ * config knob to confine the fold to half of a wider container, and a live drag tracks the finger
+ * across that whole width regardless of what Rects are configured (verified on-device: a
+ * full-width PageCurl behind a two-column spread curls the entire spread as if it were one wide
+ * leaf). The only way to get a fold anchored at the spine is to give the fold its own half-width
+ * PageCurl instance.
+ *
+ * So this renderer runs two independent PageCurl surfaces side by side, each exactly half the
+ * screen: the left one always shows even real-page indices and only ever turns backward (its fold
+ * lives at the left edge, spine on its right); the right one always shows odd real-page indices
+ * and only ever turns forward (its fold lives at the right edge, spine on its left). Both track
+ * the same spread slot; only the side facing the turn direction plays an animated fold, the other
+ * side's content swaps the instant that fold settles, driven off the animating side's own
+ * progress via snapshotFlow. This mirrors a real book: only the leaf being turned animates.
+ */
+@Composable
+internal fun SpreadPageTurnPageRenderer(
+    pagerState: PagerState,
+    chapterId: Long,
+    contentPages: List<NovelPageContentPage>,
+    transitionStyle: NovelPageTransitionStyle,
+    readerSettings: NovelReaderSettings,
+    textColor: Color,
+    textBackground: Color,
+    chapterTitleTextColor: Color,
+    backgroundTexture: NovelReaderBackgroundTexture,
+    nativeTextureStrengthPercent: Int,
+    backgroundImageModel: Any?,
+    backgroundModeIdentity: String,
+    isBackgroundMode: Boolean,
+    activeBackgroundTexture: NovelReaderBackgroundTexture,
+    activeOledEdgeGradient: Boolean,
+    isDarkTheme: Boolean,
+    pageEdgeShadow: Boolean,
+    pageEdgeShadowAlpha: Float,
+    textTypeface: Typeface?,
+    chapterTitleTypeface: Typeface?,
+    contentPadding: Dp,
+    statusBarTopPadding: Dp,
+    ttsHighlightState: NovelReaderTtsHighlightState? = null,
+    ttsHighlightColor: Color = Color.Transparent,
+    hasPreviousChapter: Boolean,
+    previousChapterName: String?,
+    hasNextChapter: Boolean,
+    nextChapterName: String?,
+    previousChapterLabel: String,
+    nextChapterLabel: String,
+    boundaryChapterHint: String,
+    showBoundaryChapterPages: Boolean = true,
+    onToggleUi: () -> Unit,
+    requestedPage: Int,
+    onRequestedPageConsumed: () -> Unit,
+    onCurrentPageChange: (Int) -> Unit,
+    onOpenPreviousChapter: () -> Unit,
+    onOpenNextChapter: () -> Unit,
+    chapterNavigationRequest: PageTurnChapterNavigationRequest? = null,
+    onChapterNavigationRequestConsumed: () -> Unit = {},
+    onTextTap: (Float, Float, Float, Float) -> Unit = { _, _, _, _ -> onToggleUi() },
+    selectionSessionIdProvider: () -> Long = { 0L },
+    onSelectedTextSelectionChanged: (NovelSelectedTextSelection?) -> Unit = {},
+) {
+    val hasPreviousChapterNavigation = hasPreviousChapter
+    val hasNextChapterNavigation = hasNextChapter
+
+    @Suppress("NAME_SHADOWING")
+    val hasPreviousChapter = hasPreviousChapter && showBoundaryChapterPages
+
+    @Suppress("NAME_SHADOWING")
+    val hasNextChapter = hasNextChapter && showBoundaryChapterPages
+
+    val safeContentPages = remember(contentPages) {
+        contentPages.ifEmpty { listOf(NovelPageContentPage(emptyList())) }
+    }
+    val spreadSlotCount = resolveSpreadSlotCount(safeContentPages.size, 2)
+    val virtualSlotCount = remember(spreadSlotCount, hasPreviousChapter, hasNextChapter) {
+        resolvePageTurnRendererVirtualPageCount(
+            contentPageCount = spreadSlotCount,
+            hasPreviousChapter = hasPreviousChapter,
+            hasNextChapter = hasNextChapter,
+        )
+    }
+    val pagerCurrentSlot = pagerState.currentPage.coerceIn(0, spreadSlotCount - 1)
+    val initialVirtualSlot = remember(pagerCurrentSlot, hasPreviousChapter) {
+        resolvePageTurnRendererVirtualPageIndex(
+            actualPageIndex = pagerCurrentSlot,
+            hasPreviousChapter = hasPreviousChapter,
+        )
+    }
+
+    // Both surfaces are seeded at the same virtual slot and only ever move together (see the two
+    // LaunchedEffects below), so they never observe each other's page content out of step.
+    val leftCurlState = rememberPageCurlState(initialCurrent = initialVirtualSlot)
+    val rightCurlState = rememberPageCurlState(initialCurrent = initialVirtualSlot)
+
+    val currentVirtualSlot = leftCurlState.current.coerceIn(0, virtualSlotCount - 1)
+    val currentSpreadSlot = resolvePageTurnRendererProgressPageIndex(
+        currentPage = currentVirtualSlot,
+        contentPageCount = spreadSlotCount,
+        hasPreviousChapter = hasPreviousChapter,
+    )
+
+    val tapCoroutineScope = rememberCoroutineScope()
+    val rendererConfig = remember(
+        transitionStyle,
+        readerSettings.pageTurnSpeed,
+        readerSettings.pageTurnIntensity,
+        readerSettings.pageTurnShadowIntensity,
+        readerSettings.pageTurnActivationZone,
+        textBackground,
+    ) {
+        resolveNovelPageTurnRendererConfig(
+            style = transitionStyle,
+            speed = readerSettings.pageTurnSpeed,
+            intensity = readerSettings.pageTurnIntensity,
+            shadowIntensity = readerSettings.pageTurnShadowIntensity,
+            activationZone = readerSettings.pageTurnActivationZone,
+            textBackground = textBackground,
+            canMoveBackward = true,
+            canMoveForward = true,
+        )
+    }
+    val tapInteraction = remember(rendererConfig) {
+        createPageTurnTapInteraction(rendererConfig)
+    }
+
+    val latestRequestedPage by rememberUpdatedState(requestedPage)
+    val latestRequestedPageConsumed by rememberUpdatedState(onRequestedPageConsumed)
+    val latestCurrentPageChange by rememberUpdatedState(onCurrentPageChange)
+    val latestOpenPreviousChapter by rememberUpdatedState(onOpenPreviousChapter)
+    val latestOpenNextChapter by rememberUpdatedState(onOpenNextChapter)
+    val latestChapterNavigationRequest by rememberUpdatedState(chapterNavigationRequest)
+    val latestChapterNavigationRequestConsumed by rememberUpdatedState(onChapterNavigationRequestConsumed)
+    val latestRendererConfig by rememberUpdatedState(rendererConfig)
+    val latestToggleUi by rememberUpdatedState(onToggleUi)
+    val latestTapToScrollEnabled by rememberUpdatedState(readerSettings.tapToScroll)
+    val latestCustomTapZonesEnabled by rememberUpdatedState(readerSettings.customTapZones)
+    val latestTapZoneActions by rememberUpdatedState(
+        parseNovelReaderTapZoneActions(readerSettings.tapZoneActions),
+    )
+    val latestHasPreviousChapter by rememberUpdatedState(hasPreviousChapterNavigation)
+    val latestHasNextChapter by rememberUpdatedState(hasNextChapterNavigation)
+
+    // Advances both surfaces together: the one facing the turn direction plays the real fold, the
+    // other jumps straight to its new page with no visible animation of its own (snap()), the same
+    // way the spine-side page of a real book is simply "already there" once you see it.
+    fun turnForward() {
+        tapCoroutineScope.launch {
+            rightCurlState.next(
+                createPageTurnAnimation(
+                    animationDurationMillis = latestRendererConfig.preset.animationDurationMillis,
+                    forward = true,
+                    curlAmount = latestRendererConfig.preset.curlAmount,
+                ),
+            )
+        }
+        tapCoroutineScope.launch {
+            leftCurlState.next(instantPageTurnAnimation())
+        }
+    }
+    fun turnBackward() {
+        tapCoroutineScope.launch {
+            leftCurlState.prev(
+                createPageTurnAnimation(
+                    animationDurationMillis = latestRendererConfig.preset.animationDurationMillis,
+                    forward = false,
+                    curlAmount = latestRendererConfig.preset.curlAmount,
+                ),
+            )
+        }
+        tapCoroutineScope.launch {
+            rightCurlState.prev(instantPageTurnAnimation())
+        }
+    }
+
+    val leftPageCurlConfig = rememberPageCurlConfig(
+        onCustomTap = { size, offset ->
+            handleSpreadCustomTap(
+                size = size,
+                offset = offset,
+                currentSpreadSlot = currentSpreadSlot,
+                spreadSlotCount = spreadSlotCount,
+                latestCustomTapZonesEnabled = latestCustomTapZonesEnabled,
+                latestTapZoneActions = latestTapZoneActions,
+                latestTapToScrollEnabled = latestTapToScrollEnabled,
+                latestRendererConfig = latestRendererConfig,
+                transitionStyle = transitionStyle,
+                latestToggleUi = latestToggleUi,
+                onTurnForward = ::turnForward,
+                onTurnBackward = ::turnBackward,
+                latestOpenPreviousChapter = latestOpenPreviousChapter,
+                latestOpenNextChapter = latestOpenNextChapter,
+            )
+        },
+    )
+    val rightPageCurlConfig = rememberPageCurlConfig(
+        onCustomTap = { size, offset ->
+            handleSpreadCustomTap(
+                size = size,
+                offset = offset,
+                currentSpreadSlot = currentSpreadSlot,
+                spreadSlotCount = spreadSlotCount,
+                latestCustomTapZonesEnabled = latestCustomTapZonesEnabled,
+                latestTapZoneActions = latestTapZoneActions,
+                latestTapToScrollEnabled = latestTapToScrollEnabled,
+                latestRendererConfig = latestRendererConfig,
+                transitionStyle = transitionStyle,
+                latestToggleUi = latestToggleUi,
+                onTurnForward = ::turnForward,
+                onTurnBackward = ::turnBackward,
+                latestOpenPreviousChapter = latestOpenPreviousChapter,
+                latestOpenNextChapter = latestOpenNextChapter,
+            )
+        },
+    )
+
+    SideEffect {
+        leftPageCurlConfig.backPageColor = rendererConfig.backPageColor
+        leftPageCurlConfig.backPageContentAlpha = 0f
+        leftPageCurlConfig.shadowColor = rendererConfig.shadowColor
+        leftPageCurlConfig.shadowAlpha = rendererConfig.preset.shadowAlpha
+        leftPageCurlConfig.shadowRadius = rendererConfig.shadowRadiusDp.dp
+        leftPageCurlConfig.shadowOffset = DpOffset(rendererConfig.shadowOffsetXDp.dp, 0.dp)
+        // The left surface only ever turns backward: its fold lives at the outer (left) edge.
+        leftPageCurlConfig.dragForwardEnabled = false
+        leftPageCurlConfig.dragBackwardEnabled = currentVirtualSlot > 0
+        leftPageCurlConfig.tapBackwardEnabled = latestTapToScrollEnabled && currentSpreadSlot > 0
+        leftPageCurlConfig.tapForwardEnabled = false
+        leftPageCurlConfig.tapCustomEnabled = rendererConfig.tapCustomEnabled
+        leftPageCurlConfig.dragInteraction = PageCurlConfig.StartEndDragInteraction(
+            pointerBehavior = rendererConfig.dragPointerBehavior,
+            backward = PageCurlConfig.StartEndDragInteraction.Config(
+                start = Rect(0f, 0f, rendererConfig.dragActivationEdgeFraction, 1f),
+                end = Rect(1f - rendererConfig.dragTargetReachFraction, 0f, 1f, 1f),
+            ),
+            forward = PageCurlConfig.StartEndDragInteraction.Config(
+                start = Rect(1f, 0f, 1f, 1f),
+                end = Rect(1f, 0f, 1f, 1f),
+            ),
+        )
+        leftPageCurlConfig.tapInteraction = tapInteraction
+
+        rightPageCurlConfig.backPageColor = rendererConfig.backPageColor
+        rightPageCurlConfig.backPageContentAlpha = 0f
+        rightPageCurlConfig.shadowColor = rendererConfig.shadowColor
+        rightPageCurlConfig.shadowAlpha = rendererConfig.preset.shadowAlpha
+        rightPageCurlConfig.shadowRadius = rendererConfig.shadowRadiusDp.dp
+        rightPageCurlConfig.shadowOffset = DpOffset(rendererConfig.shadowOffsetXDp.dp, 0.dp)
+        // The right surface only ever turns forward: its fold lives at the outer (right) edge.
+        rightPageCurlConfig.dragForwardEnabled = currentVirtualSlot < virtualSlotCount - 1
+        rightPageCurlConfig.dragBackwardEnabled = false
+        rightPageCurlConfig.tapBackwardEnabled = false
+        rightPageCurlConfig.tapForwardEnabled = latestTapToScrollEnabled && currentSpreadSlot < spreadSlotCount - 1
+        rightPageCurlConfig.tapCustomEnabled = rendererConfig.tapCustomEnabled
+        rightPageCurlConfig.dragInteraction = PageCurlConfig.StartEndDragInteraction(
+            pointerBehavior = rendererConfig.dragPointerBehavior,
+            backward = PageCurlConfig.StartEndDragInteraction.Config(
+                start = Rect(0f, 0f, 0f, 1f),
+                end = Rect(0f, 0f, 0f, 1f),
+            ),
+            forward = PageCurlConfig.StartEndDragInteraction.Config(
+                start = Rect(1f - rendererConfig.dragActivationEdgeFraction, 0f, 1f, 1f),
+                end = Rect(0f, 0f, rendererConfig.dragTargetReachFraction, 1f),
+            ),
+        )
+        rightPageCurlConfig.tapInteraction = tapInteraction
+    }
+
+    // Chapter/content changes reset both surfaces to the same slot, exactly like the single-page
+    // renderer's equivalent effect.
+    LaunchedEffect(chapterId, pagerCurrentSlot, spreadSlotCount, hasPreviousChapter) {
+        val targetVirtualSlot = resolvePageTurnRendererVirtualPageIndex(
+            actualPageIndex = pagerCurrentSlot,
+            hasPreviousChapter = hasPreviousChapter,
+        )
+        if (leftCurlState.current != targetVirtualSlot) leftCurlState.snapTo(targetVirtualSlot)
+        if (rightCurlState.current != targetVirtualSlot) rightCurlState.snapTo(targetVirtualSlot)
+    }
+
+    var consumedBoundaryNavigation by remember(chapterId, spreadSlotCount, hasPreviousChapter, hasNextChapter) {
+        mutableStateOf<HorizontalChapterSwipeAction?>(null)
+    }
+    // Drives boundary detection and the paired-surface snap off the LEFT surface's settled state:
+    // both surfaces always share one virtual slot, so either one would do, but exactly one has to
+    // own it to avoid double-firing chapter navigation.
+    LaunchedEffect(leftCurlState, spreadSlotCount, hasPreviousChapter, hasNextChapter) {
+        snapshotFlow { leftCurlState.current.coerceIn(0, virtualSlotCount - 1) to leftCurlState.progress }
+            .distinctUntilChanged()
+            .collectLatest { (targetVirtualSlot, progress) ->
+                when (
+                    resolvePageTurnRendererSettledBoundaryChapterTarget(
+                        currentPage = targetVirtualSlot,
+                        progress = progress,
+                        contentPageCount = spreadSlotCount,
+                        hasPreviousChapter = hasPreviousChapter,
+                        hasNextChapter = hasNextChapter,
+                    )
+                ) {
+                    HorizontalChapterSwipeAction.PREVIOUS -> {
+                        if (consumedBoundaryNavigation != HorizontalChapterSwipeAction.PREVIOUS) {
+                            consumedBoundaryNavigation = HorizontalChapterSwipeAction.PREVIOUS
+                            latestOpenPreviousChapter()
+                        }
+                    }
+                    HorizontalChapterSwipeAction.NEXT -> {
+                        if (consumedBoundaryNavigation != HorizontalChapterSwipeAction.NEXT) {
+                            consumedBoundaryNavigation = HorizontalChapterSwipeAction.NEXT
+                            latestOpenNextChapter()
+                        }
+                    }
+                    HorizontalChapterSwipeAction.NONE -> {}
+                }
+            }
+    }
+
+    // A live drag on the right surface (forward turn) is the library's own gesture handling, not
+    // the turnForward()/turnBackward() helpers above, so the left surface would never learn the
+    // drag happened. Watching progress here keeps it in lockstep regardless of what drove the
+    // move: a drag, a tap, or requestedPage.
+    LaunchedEffect(rightCurlState, virtualSlotCount) {
+        snapshotFlow { rightCurlState.current.coerceIn(0, virtualSlotCount - 1) to rightCurlState.progress }
+            .distinctUntilChanged()
+            .collectLatest { (target, progress) ->
+                if (progress == 0f && leftCurlState.current != target) {
+                    leftCurlState.snapTo(target)
+                }
+            }
+    }
+    LaunchedEffect(leftCurlState, virtualSlotCount) {
+        snapshotFlow { leftCurlState.current.coerceIn(0, virtualSlotCount - 1) to leftCurlState.progress }
+            .distinctUntilChanged()
+            .collectLatest { (target, progress) ->
+                if (progress == 0f && rightCurlState.current != target) {
+                    rightCurlState.snapTo(target)
+                }
+            }
+    }
+
+    LaunchedEffect(leftCurlState, pagerState, spreadSlotCount, hasPreviousChapter, hasNextChapter) {
+        snapshotFlow { leftCurlState.current.coerceIn(0, virtualSlotCount - 1) }
+            .distinctUntilChanged()
+            .collectLatest { targetVirtualSlot ->
+                val boundaryTarget = resolvePageTurnRendererBoundaryChapterTarget(
+                    currentPage = targetVirtualSlot,
+                    contentPageCount = spreadSlotCount,
+                    hasPreviousChapter = hasPreviousChapter,
+                    hasNextChapter = hasNextChapter,
+                )
+                if (boundaryTarget == HorizontalChapterSwipeAction.NONE) {
+                    val targetSpreadSlot = resolvePageTurnRendererProgressPageIndex(
+                        currentPage = targetVirtualSlot,
+                        contentPageCount = spreadSlotCount,
+                        hasPreviousChapter = hasPreviousChapter,
+                    )
+                    latestCurrentPageChange(resolveSpreadSlotFirstPageIndex(targetSpreadSlot, 2))
+                    if (targetSpreadSlot != pagerState.currentPage) {
+                        pagerState.scrollToPage(targetSpreadSlot)
+                    }
+                }
+            }
+    }
+
+    LaunchedEffect(latestRequestedPage, spreadSlotCount, hasPreviousChapter) {
+        val targetPage = latestRequestedPage
+        if (targetPage < 0 || safeContentPages.isEmpty()) return@LaunchedEffect
+        val targetSpreadSlot = resolveSpreadSlotForPageIndex(
+            targetPage.coerceIn(0, safeContentPages.lastIndex),
+            2,
+        )
+        val clampedTarget = resolvePageTurnRendererVirtualPageIndex(
+            actualPageIndex = targetSpreadSlot,
+            hasPreviousChapter = hasPreviousChapter,
+        )
+        if (leftCurlState.current != clampedTarget) leftCurlState.snapTo(clampedTarget)
+        if (rightCurlState.current != clampedTarget) rightCurlState.snapTo(clampedTarget)
+        latestRequestedPageConsumed()
+    }
+
+    LaunchedEffect(latestChapterNavigationRequest, transitionStyle) {
+        val request = latestChapterNavigationRequest ?: return@LaunchedEffect
+        if (transitionStyle != NovelPageTransitionStyle.CURL) {
+            latestChapterNavigationRequestConsumed()
+            return@LaunchedEffect
+        }
+        when (request.direction) {
+            PageTurnChapterNavigationDirection.PREVIOUS -> turnBackward()
+            PageTurnChapterNavigationDirection.NEXT -> turnForward()
+        }
+        latestChapterNavigationRequestConsumed()
+    }
+
+    BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
+        val density = LocalDensity.current
+        val halfPageSize = IntSize(
+            width = with(density) { (maxWidth / 2).roundToPx() }.coerceAtLeast(1),
+            height = with(density) { maxHeight.roundToPx() }.coerceAtLeast(1),
+        )
+        val contentPaddingPx = with(density) { contentPadding.roundToPx() }
+        val statusBarTopPaddingPx = with(density) { statusBarTopPadding.roundToPx() }
+        val snapshotCache = remember(
+            halfPageSize,
+            transitionStyle,
+            readerSettings.fontFamily,
+            readerSettings.fontSize,
+            readerSettings.lineHeight,
+            readerSettings.margin,
+            readerSettings.textAlign,
+            readerSettings.forceBoldText,
+            readerSettings.forceItalicText,
+            readerSettings.textShadow,
+            readerSettings.textShadowColor,
+            readerSettings.textShadowBlur,
+            readerSettings.textShadowX,
+            readerSettings.textShadowY,
+            readerSettings.bionicReading,
+            textColor,
+            textBackground,
+            backgroundTexture,
+            nativeTextureStrengthPercent,
+            backgroundImageModel,
+            backgroundModeIdentity,
+            isBackgroundMode,
+            activeBackgroundTexture,
+            activeOledEdgeGradient,
+            isDarkTheme,
+            chapterTitleTextColor,
+            textTypeface,
+            chapterTitleTypeface,
+            safeContentPages,
+            rendererConfig.backPageColor,
+        ) {
+            NovelPageTurnSnapshotCache<ImageBitmap>(maxSize = 6)
+        }
+
+        Row(modifier = Modifier.fillMaxSize()) {
+            SpreadColumnCurl(
+                modifier = Modifier.fillMaxWidth(0.5f),
+                columnOffset = 0,
+                pageCurlState = leftCurlState,
+                pageCurlConfig = leftPageCurlConfig,
+                virtualSlotCount = virtualSlotCount,
+                spreadSlotCount = spreadSlotCount,
+                hasPreviousChapter = hasPreviousChapter,
+                hasNextChapter = hasNextChapter,
+                showBoundaryChapterPages = showBoundaryChapterPages,
+                previousChapterLabel = previousChapterLabel,
+                nextChapterLabel = nextChapterLabel,
+                previousChapterName = previousChapterName,
+                nextChapterName = nextChapterName,
+                boundaryChapterHint = boundaryChapterHint,
+                safeContentPages = safeContentPages,
+                rendererConfig = rendererConfig,
+                pageSize = halfPageSize,
+                snapshotCache = snapshotCache,
+                contentPaddingPx = contentPaddingPx,
+                statusBarTopPaddingPx = statusBarTopPaddingPx,
+                readerSettings = readerSettings,
+                textColor = textColor,
+                textBackground = textBackground,
+                chapterTitleTextColor = chapterTitleTextColor,
+                backgroundTexture = backgroundTexture,
+                nativeTextureStrengthPercent = nativeTextureStrengthPercent,
+                backgroundImageModel = backgroundImageModel,
+                backgroundModeIdentity = backgroundModeIdentity,
+                isBackgroundMode = isBackgroundMode,
+                activeBackgroundTexture = activeBackgroundTexture,
+                activeOledEdgeGradient = activeOledEdgeGradient,
+                isDarkTheme = isDarkTheme,
+                pageEdgeShadow = pageEdgeShadow,
+                pageEdgeShadowAlpha = pageEdgeShadowAlpha,
+                textTypeface = textTypeface,
+                chapterTitleTypeface = chapterTitleTypeface,
+                contentPadding = contentPadding,
+                statusBarTopPadding = statusBarTopPadding,
+                ttsHighlightState = ttsHighlightState,
+                ttsHighlightColor = ttsHighlightColor,
+                selectionSessionIdProvider = selectionSessionIdProvider,
+                onSelectedTextSelectionChanged = onSelectedTextSelectionChanged,
+                onTextTap = onTextTap,
+            )
+            SpreadColumnCurl(
+                modifier = Modifier.fillMaxWidth(1f),
+                columnOffset = 1,
+                pageCurlState = rightCurlState,
+                pageCurlConfig = rightPageCurlConfig,
+                virtualSlotCount = virtualSlotCount,
+                spreadSlotCount = spreadSlotCount,
+                hasPreviousChapter = hasPreviousChapter,
+                hasNextChapter = hasNextChapter,
+                showBoundaryChapterPages = showBoundaryChapterPages,
+                previousChapterLabel = previousChapterLabel,
+                nextChapterLabel = nextChapterLabel,
+                previousChapterName = previousChapterName,
+                nextChapterName = nextChapterName,
+                boundaryChapterHint = boundaryChapterHint,
+                safeContentPages = safeContentPages,
+                rendererConfig = rendererConfig,
+                pageSize = halfPageSize,
+                snapshotCache = snapshotCache,
+                contentPaddingPx = contentPaddingPx,
+                statusBarTopPaddingPx = statusBarTopPaddingPx,
+                readerSettings = readerSettings,
+                textColor = textColor,
+                textBackground = textBackground,
+                chapterTitleTextColor = chapterTitleTextColor,
+                backgroundTexture = backgroundTexture,
+                nativeTextureStrengthPercent = nativeTextureStrengthPercent,
+                backgroundImageModel = backgroundImageModel,
+                backgroundModeIdentity = backgroundModeIdentity,
+                isBackgroundMode = isBackgroundMode,
+                activeBackgroundTexture = activeBackgroundTexture,
+                activeOledEdgeGradient = activeOledEdgeGradient,
+                isDarkTheme = isDarkTheme,
+                pageEdgeShadow = pageEdgeShadow,
+                pageEdgeShadowAlpha = pageEdgeShadowAlpha,
+                textTypeface = textTypeface,
+                chapterTitleTypeface = chapterTitleTypeface,
+                contentPadding = contentPadding,
+                statusBarTopPadding = statusBarTopPadding,
+                ttsHighlightState = ttsHighlightState,
+                ttsHighlightColor = ttsHighlightColor,
+                selectionSessionIdProvider = selectionSessionIdProvider,
+                onSelectedTextSelectionChanged = onSelectedTextSelectionChanged,
+                onTextTap = onTextTap,
+            )
+        }
+    }
+}
+
+/** A snap()-driven jump: the paired, non-animating side of a turn lands on its new page instantly. */
+private fun instantPageTurnAnimation(): suspend Animatable<Edge, AnimationVector4D>.(Size) -> Unit {
+    return { size ->
+        animateTo(targetValue = size.startEdge(), animationSpec = snap())
+    }
+}
+
+private fun handleSpreadCustomTap(
+    size: IntSize,
+    offset: Offset,
+    currentSpreadSlot: Int,
+    spreadSlotCount: Int,
+    latestCustomTapZonesEnabled: Boolean,
+    latestTapZoneActions: List<NovelReaderTapZoneAction>,
+    latestTapToScrollEnabled: Boolean,
+    latestRendererConfig: NovelPageTurnRendererConfig,
+    transitionStyle: NovelPageTransitionStyle,
+    latestToggleUi: () -> Unit,
+    onTurnForward: () -> Unit,
+    onTurnBackward: () -> Unit,
+    latestOpenPreviousChapter: () -> Unit,
+    latestOpenNextChapter: () -> Unit,
+): Boolean {
+    val customTapAction = if (latestCustomTapZonesEnabled) {
+        resolvePageTurnConfiguredTapAction(
+            zoneAction = resolveConfiguredNovelReaderTapAction(
+                tapX = offset.x,
+                tapY = offset.y,
+                width = size.width.toFloat(),
+                height = size.height.toFloat(),
+                customTapZonesEnabled = true,
+                tapZoneActions = latestTapZoneActions,
+                tapToScrollEnabled = latestTapToScrollEnabled,
+            ),
+            currentPage = currentSpreadSlot,
+            pageCount = spreadSlotCount.coerceAtLeast(1),
+            hasPreviousChapter = latestRendererConfig.dragBackwardEnabled,
+            hasNextChapter = latestRendererConfig.dragForwardEnabled,
+            animateBoundaryTransition = transitionStyle == NovelPageTransitionStyle.CURL,
+        )
+    } else {
+        resolvePageTurnCustomTapAction(
+            tapXFraction = if (size.width > 0) offset.x / size.width.toFloat() else 0.5f,
+            currentPage = currentSpreadSlot,
+            pageCount = spreadSlotCount.coerceAtLeast(1),
+            centerTapWidthFraction = latestRendererConfig.centerTapWidthFraction,
+            hasPreviousChapter = latestRendererConfig.dragBackwardEnabled,
+            hasNextChapter = latestRendererConfig.dragForwardEnabled,
+            tapToScrollEnabled = latestTapToScrollEnabled,
+            animateBoundaryTransition = transitionStyle == NovelPageTransitionStyle.CURL,
+        )
+    }
+    return when (customTapAction) {
+        PageTurnCustomTapAction.TOGGLE_UI -> {
+            latestToggleUi()
+            true
+        }
+        PageTurnCustomTapAction.MOVE_PREVIOUS_PAGE -> {
+            onTurnBackward()
+            true
+        }
+        PageTurnCustomTapAction.MOVE_NEXT_PAGE -> {
+            onTurnForward()
+            true
+        }
+        PageTurnCustomTapAction.OPEN_PREVIOUS_CHAPTER -> {
+            latestOpenPreviousChapter()
+            true
+        }
+        PageTurnCustomTapAction.OPEN_NEXT_CHAPTER -> {
+            latestOpenNextChapter()
+            true
+        }
+        PageTurnCustomTapAction.NONE -> false
+    }
+}
+
+@Composable
+private fun SpreadColumnCurl(
+    modifier: Modifier,
+    columnOffset: Int,
+    pageCurlState: PageCurlState,
+    pageCurlConfig: PageCurlConfig,
+    virtualSlotCount: Int,
+    spreadSlotCount: Int,
+    hasPreviousChapter: Boolean,
+    hasNextChapter: Boolean,
+    showBoundaryChapterPages: Boolean,
+    previousChapterLabel: String,
+    nextChapterLabel: String,
+    previousChapterName: String?,
+    nextChapterName: String?,
+    boundaryChapterHint: String,
+    safeContentPages: List<NovelPageContentPage>,
+    rendererConfig: NovelPageTurnRendererConfig,
+    pageSize: IntSize,
+    snapshotCache: NovelPageTurnSnapshotCache<ImageBitmap>,
+    contentPaddingPx: Int,
+    statusBarTopPaddingPx: Int,
+    readerSettings: NovelReaderSettings,
+    textColor: Color,
+    textBackground: Color,
+    chapterTitleTextColor: Color,
+    backgroundTexture: NovelReaderBackgroundTexture,
+    nativeTextureStrengthPercent: Int,
+    backgroundImageModel: Any?,
+    backgroundModeIdentity: String,
+    isBackgroundMode: Boolean,
+    activeBackgroundTexture: NovelReaderBackgroundTexture,
+    activeOledEdgeGradient: Boolean,
+    isDarkTheme: Boolean,
+    pageEdgeShadow: Boolean,
+    pageEdgeShadowAlpha: Float,
+    textTypeface: Typeface?,
+    chapterTitleTypeface: Typeface?,
+    contentPadding: Dp,
+    statusBarTopPadding: Dp,
+    ttsHighlightState: NovelReaderTtsHighlightState?,
+    ttsHighlightColor: Color,
+    selectionSessionIdProvider: () -> Long,
+    onSelectedTextSelectionChanged: (NovelSelectedTextSelection?) -> Unit,
+    onTextTap: (Float, Float, Float, Float) -> Unit,
+) {
+    PageCurl(
+        count = virtualSlotCount,
+        key = { it },
+        state = pageCurlState,
+        config = pageCurlConfig,
+        modifier = modifier.fillMaxSize(),
+    ) { page ->
+        val boundaryPreview = if (!showBoundaryChapterPages) {
+            null
+        } else {
+            when (
+                resolvePageTurnRendererBoundaryChapterTarget(
+                    currentPage = page,
+                    contentPageCount = spreadSlotCount,
+                    hasPreviousChapter = hasPreviousChapter,
+                    hasNextChapter = hasNextChapter,
+                )
+            ) {
+                HorizontalChapterSwipeAction.PREVIOUS,
+                HorizontalChapterSwipeAction.NEXT,
+                -> {
+                    createNovelPageBoundaryPreviewData(
+                        chapterLabel = if (page <= 0) previousChapterLabel else nextChapterLabel,
+                        chapterName = if (page <= 0) previousChapterName else nextChapterName,
+                        chapterHint = boundaryChapterHint,
+                    )
+                }
+                HorizontalChapterSwipeAction.NONE -> null
+            }
+        }
+        val contentPage = if (boundaryPreview == null) {
+            val spreadSlot = resolvePageTurnRendererProgressPageIndex(
+                currentPage = page,
+                contentPageCount = spreadSlotCount,
+                hasPreviousChapter = hasPreviousChapter,
+            )
+            val firstPage = resolveSpreadSlotFirstPageIndex(spreadSlot, 2)
+            safeContentPages.getOrElse(firstPage + columnOffset) { NovelPageContentPage(emptyList()) }
+        } else {
+            NovelPageContentPage(emptyList())
+        }
+        val pageTexture = if (isBackgroundMode) activeBackgroundTexture else backgroundTexture
+        val pageTextureStrengthPercent = if (isBackgroundMode) 0 else nativeTextureStrengthPercent
+        val pageSurfaceColor = if (isBackgroundMode) null else rendererConfig.backPageColor
+        val pageContentIdentity = boundaryPreview ?: contentPage
+        val pageSnapshotKey = resolveNovelPageTurnSnapshotKey(
+            style = rendererConfig.style,
+            // The two surfaces address independent PageCurl instances with their own page-index
+            // spaces, so columnOffset has to be part of the key or they would collide in the
+            // shared cache despite showing different halves of the spread.
+            pageIndex = page * 2 + columnOffset,
+            pageCount = virtualSlotCount * 2,
+            pageContentHash = pageContentIdentity.hashCode(),
+            pageSize = pageSize,
+            fontFamilyKey = readerSettings.fontFamily,
+            chapterTitleFontFamilyKey = chapterTitleTypeface?.hashCode()?.toString().orEmpty(),
+            chapterTitleTextColor = chapterTitleTextColor,
+            fontSize = readerSettings.fontSize,
+            lineHeight = readerSettings.lineHeight,
+            margin = readerSettings.margin,
+            contentPaddingPx = contentPaddingPx,
+            statusBarTopPaddingPx = statusBarTopPaddingPx,
+            textAlign = if (boundaryPreview != null) {
+                TextAlign.CENTER
+            } else {
+                readerSettings.textAlign
+            },
+            textColor = textColor,
+            textBackground = textBackground,
+            pageSurfaceColor = pageSurfaceColor ?: Color.Transparent,
+            isBackgroundMode = isBackgroundMode,
+            backgroundImageIdentity = backgroundModeIdentity,
+            backgroundTextureName = pageTexture.name,
+            nativeTextureStrengthPercentEffective = pageTextureStrengthPercent,
+            oledEdgeGradient = if (isBackgroundMode) activeOledEdgeGradient else false,
+            isDarkTheme = isDarkTheme,
+            pageEdgeShadow = pageEdgeShadow,
+            pageEdgeShadowAlpha = pageEdgeShadowAlpha,
+            backgroundTexture = pageTexture,
+            nativeTextureStrengthPercent = pageTextureStrengthPercent,
+            forceBoldText = readerSettings.forceBoldText,
+            forceItalicText = readerSettings.forceItalicText,
+            textShadow = readerSettings.textShadow,
+            textShadowColor = readerSettings.textShadowColor,
+            textShadowBlur = readerSettings.textShadowBlur,
+            textShadowX = readerSettings.textShadowX,
+            textShadowY = readerSettings.textShadowY,
+            bionicReading = readerSettings.bionicReading,
+        )
+        NovelPageTurnSnapshotRenderer(
+            snapshotKey = pageSnapshotKey,
+            snapshotCache = snapshotCache,
+            preferCachedBitmap = false,
+            modifier = Modifier.fillMaxSize(),
+        ) {
+            NovelAtmosphereBackground(
+                backgroundColor = textBackground,
+                backgroundTexture = pageTexture,
+                nativeTextureStrengthPercent = pageTextureStrengthPercent,
+                oledEdgeGradient = activeOledEdgeGradient,
+                isDarkTheme = isDarkTheme,
+                pageEdgeShadow = pageEdgeShadow,
+                pageEdgeShadowAlpha = pageEdgeShadowAlpha,
+                backgroundImageModel = backgroundImageModel,
+            )
+            if (boundaryPreview != null) {
+                NovelPageBoundaryPreviewContent(
+                    preview = boundaryPreview,
+                    textColor = textColor,
+                    chapterTitleTextColor = chapterTitleTextColor,
+                    textBackground = textBackground,
+                    contentPadding = contentPadding,
+                    statusBarTopPadding = statusBarTopPadding,
+                    textTypeface = textTypeface,
+                    chapterTitleTypeface = chapterTitleTypeface,
+                )
+            } else {
+                NovelPageReaderPageContent(
+                    contentPage = contentPage,
+                    readerSettings = readerSettings,
+                    textColor = textColor,
+                    textBackground = textBackground,
+                    pageSurfaceColor = pageSurfaceColor,
+                    backgroundTexture = pageTexture,
+                    nativeTextureStrengthPercent = pageTextureStrengthPercent,
+                    chapterTitleTextColor = chapterTitleTextColor,
+                    textTypeface = textTypeface,
+                    chapterTitleTypeface = chapterTitleTypeface,
+                    textShadowEnabled = readerSettings.textShadow,
+                    textShadowColor = readerSettings.textShadowColor,
+                    textShadowBlur = readerSettings.textShadowBlur,
+                    textShadowX = readerSettings.textShadowX,
+                    textShadowY = readerSettings.textShadowY,
+                    contentPadding = contentPadding,
+                    statusBarTopPadding = statusBarTopPadding,
+                    ttsHighlightState = ttsHighlightState,
+                    ttsHighlightColor = ttsHighlightColor,
+                    selectionSessionIdProvider = selectionSessionIdProvider,
+                    onSelectedTextSelectionChanged = onSelectedTextSelectionChanged,
+                    onPlainTap = onTextTap,
+                    touchHandlingEnabled = false,
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/eu/kanade/presentation/reader/novel/SpreadPageTurnPageRenderer.kt
+++ b/app/src/main/java/eu/kanade/presentation/reader/novel/SpreadPageTurnPageRenderer.kt
@@ -22,6 +22,7 @@ import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.zIndex
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.geometry.Size
@@ -145,10 +146,10 @@ internal fun SpreadPageTurnPageRenderer(
 
     // Both surfaces are seeded at the same virtual slot and only ever move together (see the two
     // LaunchedEffects below), so they never observe each other's page content out of step.
-    val leftCurlState = rememberPageCurlState(initialCurrent = initialVirtualSlot)
+    val leftCurlState = rememberPageCurlState(initialCurrent = (virtualSlotCount - 1 - initialVirtualSlot).coerceAtLeast(0))
     val rightCurlState = rememberPageCurlState(initialCurrent = initialVirtualSlot)
 
-    val currentVirtualSlot = leftCurlState.current.coerceIn(0, virtualSlotCount - 1)
+    val currentVirtualSlot = (virtualSlotCount - 1 - leftCurlState.current).coerceIn(0, virtualSlotCount - 1)
     val currentSpreadSlot = resolvePageTurnRendererProgressPageIndex(
         currentPage = currentVirtualSlot,
         contentPageCount = spreadSlotCount,
@@ -219,7 +220,7 @@ internal fun SpreadPageTurnPageRenderer(
             )
         }
         tapCoroutineScope.launch {
-            leftCurlState.next(instantPageTurnAnimation())
+            leftCurlState.prev(instantPageTurnAnimation())
         }
     }
     fun turnBackward() {
@@ -345,7 +346,8 @@ internal fun SpreadPageTurnPageRenderer(
             actualPageIndex = pagerCurrentSlot,
             hasPreviousChapter = hasPreviousChapter,
         )
-        if (leftCurlState.current != targetVirtualSlot) leftCurlState.snapTo(targetVirtualSlot)
+        val invertedTarget = (virtualSlotCount - 1 - targetVirtualSlot).coerceAtLeast(0)
+        if (leftCurlState.current != invertedTarget) leftCurlState.snapTo(invertedTarget)
         if (rightCurlState.current != targetVirtualSlot) rightCurlState.snapTo(targetVirtualSlot)
     }
 
@@ -359,9 +361,10 @@ internal fun SpreadPageTurnPageRenderer(
         snapshotFlow { leftCurlState.current.coerceIn(0, virtualSlotCount - 1) to leftCurlState.progress }
             .distinctUntilChanged()
             .collectLatest { (targetVirtualSlot, progress) ->
+                val realTarget = (virtualSlotCount - 1 - targetVirtualSlot).coerceAtLeast(0)
                 when (
                     resolvePageTurnRendererSettledBoundaryChapterTarget(
-                        currentPage = targetVirtualSlot,
+                        currentPage = realTarget,
                         progress = progress,
                         contentPageCount = spreadSlotCount,
                         hasPreviousChapter = hasPreviousChapter,
@@ -393,8 +396,9 @@ internal fun SpreadPageTurnPageRenderer(
         snapshotFlow { rightCurlState.current.coerceIn(0, virtualSlotCount - 1) to rightCurlState.progress }
             .distinctUntilChanged()
             .collectLatest { (target, progress) ->
-                if (progress == 0f && leftCurlState.current != target) {
-                    leftCurlState.snapTo(target)
+                val invertedTarget = (virtualSlotCount - 1 - target).coerceAtLeast(0)
+                if (progress == 0f && leftCurlState.current != invertedTarget) {
+                    leftCurlState.snapTo(invertedTarget)
                 }
             }
     }
@@ -402,8 +406,9 @@ internal fun SpreadPageTurnPageRenderer(
         snapshotFlow { leftCurlState.current.coerceIn(0, virtualSlotCount - 1) to leftCurlState.progress }
             .distinctUntilChanged()
             .collectLatest { (target, progress) ->
-                if (progress == 0f && rightCurlState.current != target) {
-                    rightCurlState.snapTo(target)
+                val realTarget = (virtualSlotCount - 1 - target).coerceAtLeast(0)
+                if (progress == 0f && rightCurlState.current != realTarget) {
+                    rightCurlState.snapTo(realTarget)
                 }
             }
     }
@@ -412,15 +417,16 @@ internal fun SpreadPageTurnPageRenderer(
         snapshotFlow { leftCurlState.current.coerceIn(0, virtualSlotCount - 1) }
             .distinctUntilChanged()
             .collectLatest { targetVirtualSlot ->
+                val realTarget = (virtualSlotCount - 1 - targetVirtualSlot).coerceAtLeast(0)
                 val boundaryTarget = resolvePageTurnRendererBoundaryChapterTarget(
-                    currentPage = targetVirtualSlot,
+                    currentPage = realTarget,
                     contentPageCount = spreadSlotCount,
                     hasPreviousChapter = hasPreviousChapter,
                     hasNextChapter = hasNextChapter,
                 )
                 if (boundaryTarget == HorizontalChapterSwipeAction.NONE) {
                     val targetSpreadSlot = resolvePageTurnRendererProgressPageIndex(
-                        currentPage = targetVirtualSlot,
+                        currentPage = realTarget,
                         contentPageCount = spreadSlotCount,
                         hasPreviousChapter = hasPreviousChapter,
                     )
@@ -443,7 +449,8 @@ internal fun SpreadPageTurnPageRenderer(
             actualPageIndex = targetSpreadSlot,
             hasPreviousChapter = hasPreviousChapter,
         )
-        if (leftCurlState.current != clampedTarget) leftCurlState.snapTo(clampedTarget)
+        val invertedTarget = (virtualSlotCount - 1 - clampedTarget).coerceAtLeast(0)
+        if (leftCurlState.current != invertedTarget) leftCurlState.snapTo(invertedTarget)
         if (rightCurlState.current != clampedTarget) rightCurlState.snapTo(clampedTarget)
         latestRequestedPageConsumed()
     }
@@ -506,8 +513,11 @@ internal fun SpreadPageTurnPageRenderer(
 
         Row(modifier = Modifier.fillMaxSize()) {
             SpreadColumnCurl(
-                modifier = Modifier.fillMaxWidth(0.5f),
+                modifier = Modifier
+                    .fillMaxWidth(0.5f)
+                    .zIndex(if (leftCurlState.progress > 0f) 1f else 0f),
                 mirrored = true,
+                invertPage = true,
                 columnOffset = 0,
                 pageCurlState = leftCurlState,
                 pageCurlConfig = leftPageCurlConfig,
@@ -552,8 +562,11 @@ internal fun SpreadPageTurnPageRenderer(
                 onTextTap = onTextTap,
             )
             SpreadColumnCurl(
-                modifier = Modifier.fillMaxWidth(1f),
+                modifier = Modifier
+                    .fillMaxWidth(1f)
+                    .zIndex(if (rightCurlState.progress > 0f) 1f else 0f),
                 mirrored = false,
+                invertPage = false,
                 columnOffset = 1,
                 pageCurlState = rightCurlState,
                 pageCurlConfig = rightPageCurlConfig,
@@ -689,6 +702,7 @@ private fun SpreadColumnCurl(
     // the library's own right-referenced geometry land on the screen's actual left edge, so this
     // surface's fold anchors at the spine the same way the unmirrored right surface already does.
     mirrored: Boolean,
+    invertPage: Boolean,
     columnOffset: Int,
     pageCurlState: PageCurlState,
     pageCurlConfig: PageCurlConfig,
@@ -744,12 +758,13 @@ private fun SpreadColumnCurl(
         config = pageCurlConfig,
         modifier = curlModifier,
     ) { page ->
+        val actualPage = if (invertPage) (virtualSlotCount - 1 - page).coerceAtLeast(0) else page
         val boundaryPreview = if (!showBoundaryChapterPages) {
             null
         } else {
             when (
                 resolvePageTurnRendererBoundaryChapterTarget(
-                    currentPage = page,
+                    currentPage = actualPage,
                     contentPageCount = spreadSlotCount,
                     hasPreviousChapter = hasPreviousChapter,
                     hasNextChapter = hasNextChapter,
@@ -759,8 +774,8 @@ private fun SpreadColumnCurl(
                 HorizontalChapterSwipeAction.NEXT,
                 -> {
                     createNovelPageBoundaryPreviewData(
-                        chapterLabel = if (page <= 0) previousChapterLabel else nextChapterLabel,
-                        chapterName = if (page <= 0) previousChapterName else nextChapterName,
+                        chapterLabel = if (actualPage <= 0) previousChapterLabel else nextChapterLabel,
+                        chapterName = if (actualPage <= 0) previousChapterName else nextChapterName,
                         chapterHint = boundaryChapterHint,
                     )
                 }
@@ -769,7 +784,7 @@ private fun SpreadColumnCurl(
         }
         val contentPage = if (boundaryPreview == null) {
             val spreadSlot = resolvePageTurnRendererProgressPageIndex(
-                currentPage = page,
+                currentPage = actualPage,
                 contentPageCount = spreadSlotCount,
                 hasPreviousChapter = hasPreviousChapter,
             )
@@ -787,7 +802,7 @@ private fun SpreadColumnCurl(
             // The two surfaces address independent PageCurl instances with their own page-index
             // spaces, so columnOffset has to be part of the key or they would collide in the
             // shared cache despite showing different halves of the spread.
-            pageIndex = page * 2 + columnOffset,
+            pageIndex = actualPage * 2 + columnOffset,
             pageCount = virtualSlotCount * 2,
             pageContentHash = pageContentIdentity.hashCode(),
             pageSize = pageSize,

--- a/app/src/main/java/eu/kanade/presentation/reader/novel/SpreadPageTurnPageRenderer.kt
+++ b/app/src/main/java/eu/kanade/presentation/reader/novel/SpreadPageTurnPageRenderer.kt
@@ -219,9 +219,6 @@ internal fun SpreadPageTurnPageRenderer(
                 ),
             )
         }
-        tapCoroutineScope.launch {
-            leftCurlState.prev(instantPageTurnAnimation())
-        }
     }
     fun turnBackward() {
         tapCoroutineScope.launch {
@@ -232,9 +229,6 @@ internal fun SpreadPageTurnPageRenderer(
                     curlAmount = latestRendererConfig.preset.curlAmount,
                 ),
             )
-        }
-        tapCoroutineScope.launch {
-            rightCurlState.prev(instantPageTurnAnimation())
         }
     }
 

--- a/app/src/main/java/eu/kanade/presentation/reader/novel/SpreadPageTurnPageRenderer.kt
+++ b/app/src/main/java/eu/kanade/presentation/reader/novel/SpreadPageTurnPageRenderer.kt
@@ -243,6 +243,7 @@ internal fun SpreadPageTurnPageRenderer(
             handleSpreadCustomTap(
                 size = size,
                 offset = offset,
+                isRightSide = false,
                 currentSpreadSlot = currentSpreadSlot,
                 spreadSlotCount = spreadSlotCount,
                 latestCustomTapZonesEnabled = latestCustomTapZonesEnabled,
@@ -263,6 +264,7 @@ internal fun SpreadPageTurnPageRenderer(
             handleSpreadCustomTap(
                 size = size,
                 offset = offset,
+                isRightSide = true,
                 currentSpreadSlot = currentSpreadSlot,
                 spreadSlotCount = spreadSlotCount,
                 latestCustomTapZonesEnabled = latestCustomTapZonesEnabled,
@@ -624,6 +626,7 @@ private fun instantPageTurnAnimation(): suspend Animatable<Edge, AnimationVector
 private fun handleSpreadCustomTap(
     size: IntSize,
     offset: Offset,
+    isRightSide: Boolean,
     currentSpreadSlot: Int,
     spreadSlotCount: Int,
     latestCustomTapZonesEnabled: Boolean,
@@ -637,12 +640,19 @@ private fun handleSpreadCustomTap(
     latestOpenPreviousChapter: () -> Unit,
     latestOpenNextChapter: () -> Unit,
 ): Boolean {
+    val fullWidth = size.width * 2f
+    val absoluteTapX = if (isRightSide) {
+        size.width + offset.x
+    } else {
+        size.width - offset.x
+    }
+
     val customTapAction = if (latestCustomTapZonesEnabled) {
         resolvePageTurnConfiguredTapAction(
             zoneAction = resolveConfiguredNovelReaderTapAction(
-                tapX = offset.x,
+                tapX = absoluteTapX,
                 tapY = offset.y,
-                width = size.width.toFloat(),
+                width = fullWidth,
                 height = size.height.toFloat(),
                 customTapZonesEnabled = true,
                 tapZoneActions = latestTapZoneActions,
@@ -656,7 +666,7 @@ private fun handleSpreadCustomTap(
         )
     } else {
         resolvePageTurnCustomTapAction(
-            tapXFraction = if (size.width > 0) offset.x / size.width.toFloat() else 0.5f,
+            tapXFraction = if (fullWidth > 0) absoluteTapX / fullWidth else 0.5f,
             currentPage = currentSpreadSlot,
             pageCount = spreadSlotCount.coerceAtLeast(1),
             centerTapWidthFraction = latestRendererConfig.centerTapWidthFraction,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/novel/setting/NovelReaderPreferences.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/novel/setting/NovelReaderPreferences.kt
@@ -74,6 +74,7 @@ data class NovelReaderSettings(
     val swipeGestures: Boolean,
     val pageReader: Boolean,
     val showPageChapterTitle: Boolean = true,
+    val twoPageLandscape: Boolean = false,
     val preferWebViewRenderer: Boolean,
     val richNativeRendererExperimental: Boolean,
     val pageTransitionStyle: NovelPageTransitionStyle = NovelPageTransitionStyle.SLIDE,
@@ -348,6 +349,7 @@ data class NovelReaderOverride(
     val swipeGestures: Boolean? = null,
     val pageReader: Boolean? = null,
     val showPageChapterTitle: Boolean? = null,
+    val twoPageLandscape: Boolean? = null,
     val preferWebViewRenderer: Boolean? = null,
     val richNativeRendererExperimental: Boolean? = null,
     val pageTransitionStyle: NovelPageTransitionStyle? = null,
@@ -551,6 +553,8 @@ class NovelReaderPreferences(
 
     fun showPageChapterTitle() =
         preferenceStore.getBoolean("novel_reader_show_page_chapter_title", true)
+
+    fun twoPageLandscape() = preferenceStore.getBoolean("novel_reader_two_page_landscape", false)
 
     fun preferWebViewRenderer() = preferenceStore.getBoolean("novel_reader_prefer_webview_renderer", false)
 
@@ -1089,6 +1093,7 @@ class NovelReaderPreferences(
                 swipeGestures = swipeGestures().get(),
                 pageReader = pageReader().get(),
                 showPageChapterTitle = showPageChapterTitle().get(),
+                twoPageLandscape = twoPageLandscape().get(),
                 preferWebViewRenderer = preferWebViewRenderer().get(),
                 richNativeRendererExperimental = richNativeRendererExperimental().get(),
                 pageTransitionStyle = pageTransitionStyle().get(),
@@ -1247,6 +1252,7 @@ class NovelReaderPreferences(
             swipeGestures = override?.swipeGestures ?: swipeGestures().get(),
             pageReader = override?.pageReader ?: pageReader().get(),
             showPageChapterTitle = override?.showPageChapterTitle ?: showPageChapterTitle().get(),
+            twoPageLandscape = override?.twoPageLandscape ?: twoPageLandscape().get(),
             preferWebViewRenderer = override?.preferWebViewRenderer ?: preferWebViewRenderer().get(),
             richNativeRendererExperimental =
             override?.richNativeRendererExperimental ?: richNativeRendererExperimental().get(),
@@ -1492,6 +1498,7 @@ class NovelReaderPreferences(
             swipeGestures().changes(),
             pageReader().changes(),
             showPageChapterTitle().changes(),
+            twoPageLandscape().changes(),
             preferWebViewRenderer().changes(),
             richNativeRendererExperimental().changes(),
             pageTransitionStyle().changes(),
@@ -1523,27 +1530,28 @@ class NovelReaderPreferences(
                 values[3] as Boolean,
                 values[4] as Boolean,
                 values[5] as Boolean,
-                (values[6] as? NovelPageTransitionStyle) ?: NovelPageTransitionStyle.SLIDE,
-                (values[7] as? NovelBookFlipAnimationSpeed) ?: NovelBookFlipAnimationSpeed.SLOW,
-                (values[8] as? NovelPageTurnSpeed) ?: NovelPageTurnSpeed.NORMAL,
-                (values[9] as? NovelPageTurnIntensity) ?: NovelPageTurnIntensity.MEDIUM,
-                (values[10] as? NovelPageTurnShadowIntensity) ?: NovelPageTurnShadowIntensity.MEDIUM,
-                (values[11] as? NovelPageTurnActivationZone) ?: NovelPageTurnActivationZone.WIDE,
-                values[12] as Boolean,
+                values[6] as Boolean,
+                (values[7] as? NovelPageTransitionStyle) ?: NovelPageTransitionStyle.SLIDE,
+                (values[8] as? NovelBookFlipAnimationSpeed) ?: NovelBookFlipAnimationSpeed.SLOW,
+                (values[9] as? NovelPageTurnSpeed) ?: NovelPageTurnSpeed.NORMAL,
+                (values[10] as? NovelPageTurnIntensity) ?: NovelPageTurnIntensity.MEDIUM,
+                (values[11] as? NovelPageTurnShadowIntensity) ?: NovelPageTurnShadowIntensity.MEDIUM,
+                (values[12] as? NovelPageTurnActivationZone) ?: NovelPageTurnActivationZone.WIDE,
                 values[13] as Boolean,
                 values[14] as Boolean,
                 values[15] as Boolean,
                 values[16] as Boolean,
-                values[17] as Int,
+                values[17] as Boolean,
                 values[18] as Int,
-                (values[19] as? NovelAutoScrollChapterEndBehavior) ?: NovelAutoScrollChapterEndBehavior.StopAtEnd,
-                values[20] as Boolean,
-                values[21] as Long,
-                values[22] as Boolean,
+                values[19] as Int,
+                (values[20] as? NovelAutoScrollChapterEndBehavior) ?: NovelAutoScrollChapterEndBehavior.StopAtEnd,
+                values[21] as Boolean,
+                values[22] as Long,
                 values[23] as Boolean,
                 values[24] as Boolean,
-                values[25] as String,
-                values[26] as Boolean,
+                values[25] as Boolean,
+                values[26] as String,
+                values[27] as Boolean,
             )
         }.distinctUntilChanged()
 
@@ -1795,6 +1803,7 @@ class NovelReaderPreferences(
                 swipeGestures = override?.swipeGestures ?: navigation.swipeGestures,
                 pageReader = override?.pageReader ?: navigation.pageReader,
                 showPageChapterTitle = override?.showPageChapterTitle ?: navigation.showPageChapterTitle,
+                twoPageLandscape = override?.twoPageLandscape ?: navigation.twoPageLandscape,
                 preferWebViewRenderer = override?.preferWebViewRenderer ?: navigation.preferWebViewRenderer,
                 richNativeRendererExperimental =
                 override?.richNativeRendererExperimental ?: navigation.richNativeRendererExperimental,
@@ -1951,6 +1960,7 @@ class NovelReaderPreferences(
         val swipeGestures: Boolean,
         val pageReader: Boolean,
         val showPageChapterTitle: Boolean,
+        val twoPageLandscape: Boolean,
         val preferWebViewRenderer: Boolean,
         val richNativeRendererExperimental: Boolean,
         val pageTransitionStyle: NovelPageTransitionStyle,

--- a/app/src/test/java/eu/kanade/presentation/reader/novel/NovelReaderInteractionTest.kt
+++ b/app/src/test/java/eu/kanade/presentation/reader/novel/NovelReaderInteractionTest.kt
@@ -109,4 +109,56 @@ class NovelReaderInteractionTest {
             chapterHandoffTarget = NovelReaderPageReaderHandoffTarget.START,
         ) shouldBe page0Progress
     }
+
+    @Test
+    fun `spread columns require landscape, enough width, and the preference on`() {
+        resolveNovelSpreadColumns(
+            twoPageLandscapeEnabled = true,
+            viewportWidthPx = 2000,
+            viewportHeightPx = 1000,
+            minSpreadWidthPx = 1800,
+        ) shouldBe 2
+
+        resolveNovelSpreadColumns(
+            twoPageLandscapeEnabled = false,
+            viewportWidthPx = 2000,
+            viewportHeightPx = 1000,
+            minSpreadWidthPx = 1800,
+        ) shouldBe 1
+
+        resolveNovelSpreadColumns(
+            twoPageLandscapeEnabled = true,
+            viewportWidthPx = 1000,
+            viewportHeightPx = 2000,
+            minSpreadWidthPx = 1800,
+        ) shouldBe 1
+
+        resolveNovelSpreadColumns(
+            twoPageLandscapeEnabled = true,
+            viewportWidthPx = 1200,
+            viewportHeightPx = 1000,
+            minSpreadWidthPx = 1800,
+        ) shouldBe 1
+    }
+
+    @Test
+    fun `spread slot count collapses pages into pairs and keeps a trailing odd page`() {
+        resolveSpreadSlotCount(contentPageCount = 10, columnsPerSpread = 2) shouldBe 5
+        resolveSpreadSlotCount(contentPageCount = 9, columnsPerSpread = 2) shouldBe 5
+        resolveSpreadSlotCount(contentPageCount = 9, columnsPerSpread = 1) shouldBe 9
+        resolveSpreadSlotCount(contentPageCount = 0, columnsPerSpread = 2) shouldBe 1
+    }
+
+    @Test
+    fun `spread slot first page index and page-to-slot mapping round trip`() {
+        resolveSpreadSlotFirstPageIndex(spreadSlot = 0, columnsPerSpread = 2) shouldBe 0
+        resolveSpreadSlotFirstPageIndex(spreadSlot = 3, columnsPerSpread = 2) shouldBe 6
+
+        resolveSpreadSlotForPageIndex(pageIndex = 0, columnsPerSpread = 2) shouldBe 0
+        resolveSpreadSlotForPageIndex(pageIndex = 1, columnsPerSpread = 2) shouldBe 0
+        resolveSpreadSlotForPageIndex(pageIndex = 2, columnsPerSpread = 2) shouldBe 1
+        resolveSpreadSlotForPageIndex(pageIndex = 7, columnsPerSpread = 2) shouldBe 3
+
+        resolveSpreadSlotForPageIndex(pageIndex = 5, columnsPerSpread = 1) shouldBe 5
+    }
 }

--- a/i18n-aniyomi/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n-aniyomi/src/commonMain/moko-resources/base/strings.xml
@@ -648,6 +648,8 @@
     <string name="novel_reader_page_mode_summary">Display content in pages instead of continuous scroll</string>
     <string name="novel_reader_show_page_chapter_title">Show chapter title</string>
     <string name="novel_reader_show_page_chapter_title_summary">Display chapter titles in Page mode</string>
+    <string name="novel_reader_two_page_landscape">Two-page landscape</string>
+    <string name="novel_reader_two_page_landscape_summary">Show two pages side by side when the device is landscape and wide enough</string>
     <string name="novel_reader_page_transition_style">Page transition style</string>
     <string name="novel_reader_page_transition_style_instant">Instant</string>
     <string name="novel_reader_page_transition_style_slide">Slide</string>


### PR DESCRIPTION
## Summary

- Add a "Two-page landscape" preference for the novel reader that renders spreads as two pages side by side instead of one
  - Implement spread rendering in the pager and page-curl renderers, including a new `SpreadPageTurnPageRenderer` for the curl animation across two pages
  - Anchor the curl fold at the spine so forward/backward turns pivot correctly between the left and right pages in a spread
  - Fix page clipping and backward dragging in spread mode
  - Map tap zones to absolute screen coordinates so edge taps register correctly in spread mode
  - Fix a missing page turn animation when tapping edges in spread mode
- Solves #179 

### Images

<img width="1079" height="497" alt="image" src="https://github.com/user-attachments/assets/594da691-ede3-470e-9362-1eb4506833da" />
<img width="719" height="405" alt="image" src="https://github.com/user-attachments/assets/5c81d742-84bf-4e32-a117-ce560a57eedc" />

### AI Disclaimer

Fully implemented with Claude Code - Sonnet 5 & Antigravity CLI - Gemini 3.1 Pro.

## Validation

- [x] I ran the required automated checks for this change.
- [x] I self-reviewed the diff and validated critical user flows.
